### PR TITLE
Reword description in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,5 +4,6 @@
 [![Test Coverage](https://api.codeclimate.com/v1/badges/4b224cde0ea92d686d7a/test_coverage)](https://codeclimate.com/github/multimatum-Team/multimatum/test_coverage)
 [![Maintainability](https://api.codeclimate.com/v1/badges/4b224cde0ea92d686d7a/maintainability)](https://codeclimate.com/github/multimatum-Team/multimatum/maintainability)
 
-Deadlines manager app for SDP, spring semester 2022
+Multimatum is a deadlines manager application for Android, made for the
+software development project course, spring semester 2022.
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 # multimatum
 
+[![Build Status](https://api.cirrus-ci.com/github/Multimatum-Team/multimatum.svg)](https://cirrus-ci.com/github/multimatum-Team/multimatum)
+[![Test Coverage](https://api.codeclimate.com/v1/badges/4b224cde0ea92d686d7a/test_coverage)](https://codeclimate.com/github/multimatum-Team/multimatum/test_coverage)
+[![Maintainability](https://api.codeclimate.com/v1/badges/4b224cde0ea92d686d7a/maintainability)](https://codeclimate.com/github/multimatum-Team/multimatum/maintainability)
+
 Deadlines manager app for SDP, spring semester 2022
 
-[![Build Status](https://api.cirrus-ci.com/github/Multimatum-Team/multimatum.svg)](https://cirrus-ci.com/github/multimatum-Team/multimatum)
-
-[![Test Coverage](https://api.codeclimate.com/v1/badges/4b224cde0ea92d686d7a/test_coverage)](https://codeclimate.com/github/multimatum-Team/multimatum/test_coverage)
-
-[![Maintainability](https://api.codeclimate.com/v1/badges/4b224cde0ea92d686d7a/maintainability)](https://codeclimate.com/github/multimatum-Team/multimatum/maintainability)


### PR DESCRIPTION
This PR rewords the application description in the README.
I also changed the CI badges to be on the same line, and put them right below the title as done most repos.