### PR TITLE
Add clock service to enable reproducible testing

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,7 +17,7 @@
         android:theme="@style/Theme.Multimatum">
 
         <service
-            android:name=".procrastination_detector.ProcrastinationDetectorService"
+            android:name=".service.ProcrastinationDetectorService"
             android:enabled="true"
             android:exported="false" />
         <activity

--- a/app/src/main/java/com/github/multimatum_team/multimatum/DependenciesProvider.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/DependenciesProvider.kt
@@ -9,6 +9,9 @@ import com.github.multimatum_team.multimatum.model.DeadlineState
 import com.github.multimatum_team.multimatum.repository.DeadlineRepository
 import com.github.multimatum_team.multimatum.repository.FirebaseDeadlineRepository
 import android.hardware.SensorManager
+import android.os.SystemClock
+import com.github.multimatum_team.multimatum.service.ClockService
+import com.github.multimatum_team.multimatum.service.SystemClockService
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -30,6 +33,14 @@ object DependenciesProvider {
     @Provides
     fun provideSensorManager(@ApplicationContext applicationContext: Context): SensorManager =
         applicationContext.getSystemService(SENSOR_SERVICE) as SensorManager
+}
+
+@Module
+@InstallIn(SingletonComponent::class)
+object ClockModule {
+    @Provides
+    fun provideClockService(): ClockService =
+        SystemClockService()
 }
 
 @Module

--- a/app/src/main/java/com/github/multimatum_team/multimatum/MainSettingsActivity.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/MainSettingsActivity.kt
@@ -7,7 +7,7 @@ import android.os.Bundle
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.SwitchCompat
-import com.github.multimatum_team.multimatum.procrastination_detector.ProcrastinationDetectorService
+import com.github.multimatum_team.multimatum.service.ProcrastinationDetectorService
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 

--- a/app/src/main/java/com/github/multimatum_team/multimatum/model/Deadline.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/model/Deadline.kt
@@ -1,6 +1,5 @@
 package com.github.multimatum_team.multimatum.model
 
-import com.google.type.Date
 import java.time.LocalDate
 import java.time.Period
 
@@ -44,22 +43,4 @@ data class Deadline(
             throw IllegalArgumentException()
         }
     }
-
-    /**
-     * Returns how much time is left to complete the task before the deadline.
-     * If the deadline is due, return null.
-     */
-    val timeRemaining: Period?
-        get() =
-            if (isDue)
-                null
-            else {
-                Period.between(LocalDate.now(), date)
-            }
-
-    /**
-     * Tells whether the deadline has passed.
-     */
-    val isDue: Boolean
-        get() = LocalDate.now() > date
 }

--- a/app/src/main/java/com/github/multimatum_team/multimatum/model/Deadline.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/model/Deadline.kt
@@ -1,7 +1,6 @@
 package com.github.multimatum_team.multimatum.model
 
 import java.time.LocalDate
-import java.time.Period
 
 /**
  * The state of a deadline.

--- a/app/src/main/java/com/github/multimatum_team/multimatum/model/DeadlineAdapter.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/model/DeadlineAdapter.kt
@@ -16,7 +16,6 @@ import dagger.hilt.InstallIn
 import dagger.hilt.android.EntryPointAccessors
 import dagger.hilt.components.SingletonComponent
 import java.time.Period
-import javax.inject.Inject
 
 @EntryPoint
 @InstallIn(SingletonComponent::class)
@@ -29,7 +28,7 @@ Class which is used to show the deadline in a clear list.
 Based on the tutorial:
 https://www.raywenderlich.com/155-android-listview-tutorial-with-kotlin
  */
-class DeadlineAdapter @Inject constructor(private val context: Context) : BaseAdapter() {
+class DeadlineAdapter(private val context: Context) : BaseAdapter() {
     companion object {
         // value who define when there is not much time left for a deadline
         const val URGENT = 5

--- a/app/src/main/java/com/github/multimatum_team/multimatum/service/ClockService.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/service/ClockService.kt
@@ -1,0 +1,20 @@
+package com.github.multimatum_team.multimatum.service
+
+import java.time.Clock
+import java.time.LocalDate
+
+/**
+ * An interface for providing date and time.
+ */
+interface ClockService {
+    /**
+     * Return the clock used by the service.
+     */
+    fun getClock(): Clock
+
+    /**
+     * Get the local date provided by the clock.
+     */
+    fun now(): LocalDate =
+        LocalDate.now(getClock())
+}

--- a/app/src/main/java/com/github/multimatum_team/multimatum/service/ProcrastinationDetectorService.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/service/ProcrastinationDetectorService.kt
@@ -1,4 +1,4 @@
-package com.github.multimatum_team.multimatum.procrastination_detector
+package com.github.multimatum_team.multimatum.service
 
 import android.app.Service
 import android.content.Intent

--- a/app/src/main/java/com/github/multimatum_team/multimatum/service/SystemClockService.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/service/SystemClockService.kt
@@ -2,7 +2,11 @@ package com.github.multimatum_team.multimatum.service
 
 import java.time.Clock
 
-class SystemClockService() : ClockService {
+/**
+ * A real implementation of the clock service.
+ * Uses the system clock to return the real time at which the code is executed.
+ */
+class SystemClockService : ClockService {
     override fun getClock(): Clock =
         Clock.systemDefaultZone()
 }

--- a/app/src/main/java/com/github/multimatum_team/multimatum/service/SystemClockService.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/service/SystemClockService.kt
@@ -1,0 +1,8 @@
+package com.github.multimatum_team.multimatum.service
+
+import java.time.Clock
+
+class SystemClockService() : ClockService {
+    override fun getClock(): Clock =
+        Clock.systemDefaultZone()
+}

--- a/app/src/test/java/com/github/multimatum_team/multimatum/DeadlineAdapterTest.kt
+++ b/app/src/test/java/com/github/multimatum_team/multimatum/DeadlineAdapterTest.kt
@@ -7,7 +7,6 @@ import android.view.View
 import android.widget.ListView
 import android.widget.TextView
 import androidx.test.core.app.ApplicationProvider
-import androidx.test.espresso.intent.Intents
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.multimatum_team.multimatum.model.Deadline
 import com.github.multimatum_team.multimatum.model.DeadlineAdapter

--- a/app/src/test/java/com/github/multimatum_team/multimatum/DeadlineAdapterTest.kt
+++ b/app/src/test/java/com/github/multimatum_team/multimatum/DeadlineAdapterTest.kt
@@ -7,18 +7,38 @@ import android.view.View
 import android.widget.ListView
 import android.widget.TextView
 import androidx.test.core.app.ApplicationProvider
+import androidx.test.espresso.intent.Intents
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.multimatum_team.multimatum.model.Deadline
 import com.github.multimatum_team.multimatum.model.DeadlineAdapter
 import com.github.multimatum_team.multimatum.model.DeadlineState
+import com.github.multimatum_team.multimatum.service.ClockService
+import com.github.multimatum_team.multimatum.util.MockClockService
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import dagger.hilt.android.testing.UninstallModules
+import dagger.hilt.components.SingletonComponent
 import org.junit.Assert
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.time.LocalDate
+import javax.inject.Inject
 
 @RunWith(AndroidJUnit4::class)
+@HiltAndroidTest
+@UninstallModules(ClockModule::class)
 class DeadlineAdapterTest {
+    @get:Rule
+    var hiltRule = HiltAndroidRule(this)
+
+    @Inject
+    lateinit var clockService: ClockService
+
     private lateinit var adapter: DeadlineAdapter
     private var context: Application? = null
     private lateinit var list: List<Deadline>
@@ -26,11 +46,12 @@ class DeadlineAdapterTest {
     @Before
     @Throws(Exception::class)
     fun setUp() {
+        hiltRule.inject()
         context = ApplicationProvider.getApplicationContext()
         adapter = DeadlineAdapter(context!!)
         list = listOf(
-            Deadline("Number 1", DeadlineState.TODO, LocalDate.now().plusDays(1)),
-            Deadline("Number 2", DeadlineState.TODO, LocalDate.now().plusDays(7)),
+            Deadline("Number 1", DeadlineState.TODO, clockService.now().plusDays(1)),
+            Deadline("Number 2", DeadlineState.TODO, clockService.now().plusDays(7)),
             Deadline("Number 3", DeadlineState.DONE, LocalDate.of(2022, 3, 30)),
             Deadline("Number 4", DeadlineState.TODO, LocalDate.of(2022, 3, 1))
         )
@@ -206,4 +227,11 @@ class DeadlineAdapterTest {
         )
     }
 
+    @Module
+    @InstallIn(SingletonComponent::class)
+    object TestClockModule {
+        @Provides
+        fun provideClockService(): ClockService =
+            MockClockService(LocalDate.of(2022, 3, 12))
+    }
 }

--- a/app/src/test/java/com/github/multimatum_team/multimatum/DeadlineTests.kt
+++ b/app/src/test/java/com/github/multimatum_team/multimatum/DeadlineTests.kt
@@ -2,31 +2,16 @@ package com.github.multimatum_team.multimatum
 
 import com.github.multimatum_team.multimatum.model.Deadline
 import com.github.multimatum_team.multimatum.model.DeadlineState
-import io.mockk.every
-import io.mockk.mockkStatic
-import org.junit.Assert.*
-import org.junit.Before
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
 import org.junit.Test
-import java.time.*
+import java.time.LocalDate
+import java.time.Month
 
 /**
  * Unit tests for the Deadline class.
  */
 class DeadlineTests {
-    /**
-     * This snippet was inspired from
-     * https://nieldw.medium.com/unit-testing-fixing-the-system-clock-with-mockk-fc6991afb766
-     */
-
-    private val now = 1646920323881L
-    private val fixedClock = Clock.fixed(Instant.ofEpochMilli(now), ZoneId.of("UTC"))
-
-    @Before
-    fun `Fix the clock to ensure test reproducibility`() {
-        mockkStatic(Clock::class)
-        every { Clock.systemUTC() } returns fixedClock
-    }
-
     @Test
     fun `Constructor should return Deadline instance defining the right properties`() {
         val title = "Implement tests for Deadline class"
@@ -47,49 +32,5 @@ class DeadlineTests {
                 LocalDate.of(2022, Month.MARCH, 9)
             )
         }
-    }
-
-    @Test
-    fun `timeRemaining returns difference between now and endDate`() {
-        val now = LocalDate.now()
-        val days = Period.ofDays(3)
-        val deadline = Deadline(
-            "Implement tests for Deadline class",
-            DeadlineState.DONE,
-            now.plus(days)
-        )
-        assertEquals(deadline.timeRemaining, days)
-    }
-
-    @Test
-    fun `timeRemaining returns null if endDate has passed`() {
-        val now = LocalDate.now()
-        val deadline = Deadline(
-            "Implement tests for Deadline class",
-            DeadlineState.DONE,
-            now.minusDays(1)
-        )
-        assertNull(deadline.timeRemaining)
-    }
-
-    @Test
-    fun `isDue returns true when deadline has passed`() {
-        val deadline = Deadline(
-            "Implement tests for Deadline class",
-            DeadlineState.DONE,
-            LocalDate.now().minusDays(1)
-        )
-        assertTrue(deadline.isDue)
-    }
-
-    @Test
-    fun `isDue returns false if endDate is in the future`() {
-        val days = Period.ofDays(3)
-        val deadline = Deadline(
-            "Implement tests for Deadline class",
-            DeadlineState.DONE,
-            LocalDate.now().plus(days)
-        )
-        assertFalse(deadline.isDue)
     }
 }

--- a/app/src/test/java/com/github/multimatum_team/multimatum/util/MockClockService.kt
+++ b/app/src/test/java/com/github/multimatum_team/multimatum/util/MockClockService.kt
@@ -5,7 +5,6 @@ import java.time.Clock
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneId
-import java.time.temporal.ChronoField
 
 /**
  * A mock class to simulate a fixed clock.

--- a/app/src/test/java/com/github/multimatum_team/multimatum/util/MockClockService.kt
+++ b/app/src/test/java/com/github/multimatum_team/multimatum/util/MockClockService.kt
@@ -1,0 +1,20 @@
+package com.github.multimatum_team.multimatum.util
+
+import com.github.multimatum_team.multimatum.service.ClockService
+import java.time.Clock
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.temporal.ChronoField
+
+/**
+ * A mock class to simulate a fixed clock.
+ * This lets us write more reproducible tests.
+ */
+class MockClockService(private var date: LocalDate) : ClockService {
+    override fun getClock(): Clock =
+        Clock.fixed(
+            Instant.ofEpochSecond(date.atStartOfDay(ZoneId.of("UTC")).toEpochSecond()),
+            ZoneId.of("UTC")
+        )
+}


### PR DESCRIPTION
This PR implements a `ClockService` interface that enables one to get the clock and (local) date. The real implementation of the service is provided by the `SystemClockService` class, giving the actual date at which the code is executed. The purpose of this service is to be able to use dependency injection to inject a mock clock in time-sensitive code. This lets us write reproducible tests that won't fail when executed at certain times.

Closes #92 