### PR TITLE
Fix datetime not being correctly serialized into firebase

### DIFF
--- a/app/src/main/java/com/github/multimatum_team/multimatum/repository/FirebaseDeadlineRepository.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/repository/FirebaseDeadlineRepository.kt
@@ -30,7 +30,12 @@ class FirebaseDeadlineRepository @Inject constructor() : DeadlineRepository {
         hashMapOf(
             "title" to deadline.title,
             "state" to deadline.state.ordinal,
-            "date" to deadline.dateTime
+            "date" to Timestamp(
+                deadline.dateTime
+                    .atZone(ZoneId.systemDefault())
+                    .toEpochSecond(),
+                0
+            )
         )
 
     /**


### PR DESCRIPTION
This PR fixes a bug that caused the deadline dates to be inserted into the Firebase database as is, without being properly serialized. As a consequence, we couldn't add deadlines using neither the calendar or the add deadline button.
This wouldn't happen if we had proper tests for the firebase repository, we should find a way to use the firebase emulator suite.