### PR TITLE
Increase threshold CodeClimate

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,3 +1,8 @@
+checks:
+  similar-code:
+    config:
+      threshold: 250
+      
 exclude_patterns:
   - "**/test/"
   - "**/androidTest/"


### PR DESCRIPTION
Currently, CodeClimate is very harsh on the maintainability of the code, mainly about the similarity of the code.
This PR increase the threshold of codeclimate to inform us of a repetiton of code only if there are more than 250 characters similar.