### PR TITLE
Feature/procrastination detector foreground service

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -36,7 +36,7 @@
             android:name=".QRCodeReaderActivity"
             android:exported="false" />
         <activity android:name=".MainSettingsActivity"
-            android:exported="true">
+            android:exported="false">
         </activity>
         <activity
             android:name=".AccountActivity"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,8 @@
 
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
     <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
 
     <application
         android:name=".MultimatumApp"
@@ -33,9 +35,9 @@
         <activity
             android:name=".QRCodeReaderActivity"
             android:exported="false" />
-        <activity
-            android:name=".MainSettingsActivity"
-            android:exported="false" />
+        <activity android:name=".MainSettingsActivity"
+            android:exported="true">
+        </activity>
         <activity
             android:name=".AccountActivity"
             android:exported="false"
@@ -49,7 +51,6 @@
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>

--- a/app/src/main/java/com/github/multimatum_team/multimatum/MainSettingsActivity.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/MainSettingsActivity.kt
@@ -60,8 +60,8 @@ class MainSettingsActivity : AppCompatActivity() {
         }
         procrastinationDetectEnabledButton.setOnCheckedChangeListener { _, newState ->
             when (newState) {
-                true -> startService(Intent(applicationContext, ProcrastinationDetectorService::class.java))
-                false -> stopService(Intent(applicationContext, ProcrastinationDetectorService::class.java))
+                true -> ProcrastinationDetectorService.launch(this)
+                false -> ProcrastinationDetectorService.stop(this)
             }
             writeNewState(PROCRASTINATION_FIGHTER_ENABLED_PREF_KEY, newState)
         }

--- a/app/src/main/java/com/github/multimatum_team/multimatum/service/ProcrastinationDetectorService.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/service/ProcrastinationDetectorService.kt
@@ -1,14 +1,19 @@
 package com.github.multimatum_team.multimatum.service
 
-import android.app.Service
+import android.app.*
+import android.content.Context
 import android.content.Intent
+import android.graphics.Color
 import android.hardware.Sensor
 import android.hardware.SensorEvent
 import android.hardware.SensorEventListener
 import android.hardware.SensorManager
 import android.os.Binder
 import android.os.IBinder
+import android.os.PowerManager
+import android.util.Log
 import android.widget.Toast
+import com.github.multimatum_team.multimatum.MainSettingsActivity
 import com.github.multimatum_team.multimatum.R
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -17,6 +22,8 @@ import kotlin.math.abs
 /**
  * This service detects the movements of the phone to deduce whether the user is
  * working or not, and can display a reminder if necessary
+ *
+ * Adapted from https://robertohuertas.com/2019/06/29/android_foreground_services/
  */
 @AndroidEntryPoint
 class ProcrastinationDetectorService : Service(), SensorEventListener {
@@ -25,30 +32,103 @@ class ProcrastinationDetectorService : Service(), SensorEventListener {
 
     // TODO make it remain enabled when app is stopped
 
+    private var isServiceStarted = false
+    private var wakeLock: PowerManager.WakeLock? = null
+
     // data relative to the last time a movement was detected
     private var lastDetectionTimestamp: Long = 0L
     private var lastPosition: Array<Float>? = null  // null only at initialization
 
     private val binder = PdsBinder()
 
-    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
-        super.onStartCommand(intent, flags, startId)
-        val refSensor = sensorManager.getDefaultSensor(REF_SENSOR)
-            ?: throw IllegalStateException("missing sensor")
-        sensorManager.registerListener(this, refSensor, SensorManager.SENSOR_DELAY_NORMAL)
-        toast(getString(R.string.procrastination_fighter_enable_msg))
-        return START_STICKY  // service must restart as soon as possible if preempted
-    }
-
     override fun onBind(intent: Intent): IBinder {
         return binder
     }
 
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        if (intent != null) {
+            when (val action = intent.action) {
+                START_ACTION -> startProcrastinationDetectorService()
+                STOP_ACTION -> stopProcrastinationDetectorService()
+                else -> throw IllegalStateException("unexpected action: $action")
+            }
+        }
+        return START_STICKY  // service must restart as soon as possible if preempted
+    }
+
+    override fun onCreate() {
+        super.onCreate()
+        Log.d(LOG_TAG, "Service created")
+        startForeground(1, createNotification())
+    }
+
     override fun onDestroy() {
         super.onDestroy()
+        Log.d(LOG_TAG, "Service destroyed")
+    }
+
+    private fun startProcrastinationDetectorService() {
+        if (isServiceStarted) {
+            return
+        }
+        toast("Procrastination detector enabled")
+        isServiceStarted = true
+        // FIXME possibly need to store in sharedPref that service is active
+        wakeLock = (getSystemService(Context.POWER_SERVICE) as PowerManager).run {
+            newWakeLock(
+                PowerManager.PARTIAL_WAKE_LOCK,
+                "ProcrastinationDetectorService::lock"
+            ).apply {
+                acquire(10 * 60 * 1000L /*10 minutes*/) // FIXME style
+            }
+        }
+        // FIXME possibly need for a loop here
+        val refSensor = sensorManager.getDefaultSensor(REF_SENSOR)
+            ?: throw IllegalStateException("missing sensor")
+        sensorManager.registerListener(this, refSensor, SensorManager.SENSOR_DELAY_NORMAL)
+    }
+
+    private fun stopProcrastinationDetectorService() {
         val refSensor = sensorManager.getDefaultSensor(REF_SENSOR)
         sensorManager.unregisterListener(this, refSensor)
         toast(getString(R.string.procrastination_fighter_disabled_msg))
+        wakeLock?.let {
+            if (it.isHeld) {
+                it.release()
+            }
+        }
+        stopForeground(true)
+        stopSelf()
+        isServiceStarted = false
+        // FIXME possibly need to store state in SharedPreferences
+    }
+
+    private fun createNotification(): Notification {
+        val notificationManager =
+            getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        val channel = NotificationChannel(
+            NOTIFICATION_CHANNEL_ID,
+            "Procrastination detector notifications channel",
+            NotificationManager.IMPORTANCE_HIGH
+        )
+        channel.description = "Procrastination detector channel"
+        channel.enableLights(true)
+        channel.lightColor = Color.RED
+        notificationManager.createNotificationChannel(channel)
+        val pendingIntent =
+            PendingIntent.getActivity(
+                this,
+                0,
+                Intent(this, MainSettingsActivity::class.java),
+                PendingIntent.FLAG_IMMUTABLE
+            )
+        val builder = Notification.Builder(this, NOTIFICATION_CHANNEL_ID)
+        return builder.setContentTitle("Procrastination detector")
+            .setContentText("Procrastination is bad...")
+            .setContentIntent(pendingIntent)
+            .setSmallIcon(R.drawable.ic_launcher_foreground)
+            .setTicker("Ticker text")
+            .build()
     }
 
     override fun onAccuracyChanged(sensor: Sensor?, accuracy: Int) {
@@ -57,6 +137,7 @@ class ProcrastinationDetectorService : Service(), SensorEventListener {
 
     override fun onSensorChanged(event: SensorEvent?) {
         requireNotNull(event)
+        Log.d(LOG_TAG, "sensor change detected")
         val currentTime = event.timestamp
         // check whether enough time has passed since the last detection (o.w. do nothing)
         if (currentTime >= lastDetectionTimestamp + MIN_PERIOD_BETWEEN_NOTIF_NANOSEC) {
@@ -93,7 +174,7 @@ class ProcrastinationDetectorService : Service(), SensorEventListener {
          * The sensor used by this service to detect movements
          */
         const val REF_SENSOR = Sensor.TYPE_GRAVITY
-      
+
         private const val MIN_PERIOD_BETWEEN_NOTIF_NANOSEC = 2_000_000_000L
 
         /**
@@ -101,6 +182,29 @@ class ProcrastinationDetectorService : Service(), SensorEventListener {
          * the sensors, which have no unit themselves
          */
         private const val MOVE_DETECTION_THRESHOLD = 0.1
+
+        private const val LOG_TAG = "ProcrastinationDetectorService"
+
+        private const val NOTIFICATION_CHANNEL_ID =
+            "com.github.multimatum_team-mutlimatum.ProcrastinationDetectorServiceChannel"
+
+        private const val START_ACTION =
+            "com.github.multimatum_team.multimatum.StartProcrastinationDetectorServiceAction"
+        private const val STOP_ACTION =
+            "com.github.multimatum_team.multimatum.StopProcrastinationDetectorServiceAction"
+
+        fun launch(caller: Context) {
+            val intent = Intent(caller, ProcrastinationDetectorService::class.java)
+            intent.action = START_ACTION
+            caller.startForegroundService(intent)
+        }
+
+        fun stop(caller: Context) {
+            val intent = Intent(caller, ProcrastinationDetectorService::class.java)
+            intent.action = STOP_ACTION
+            caller.startForegroundService(intent)
+        }
+
     }
 
     inner class PdsBinder : Binder() {

--- a/app/src/main/java/com/github/multimatum_team/multimatum/service/ProcrastinationDetectorService.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/service/ProcrastinationDetectorService.kt
@@ -43,7 +43,8 @@ class ProcrastinationDetectorService : Service(), SensorEventListener {
         return binder
     }
 
-    // also used to stop the service, when action is STOP_ACTION
+    // when intent.action is START_ACTION, starts the service
+    // when intent.action is STOP_ACTION, stops the service
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         if (intent != null) {
             when (val action = intent.action) {

--- a/app/src/main/java/com/github/multimatum_team/multimatum/service/ProcrastinationDetectorService.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/service/ProcrastinationDetectorService.kt
@@ -16,7 +16,6 @@ import android.widget.Toast
 import com.github.multimatum_team.multimatum.MainSettingsActivity
 import com.github.multimatum_team.multimatum.R
 import dagger.hilt.android.AndroidEntryPoint
-import java.lang.IllegalArgumentException
 import javax.inject.Inject
 import kotlin.math.abs
 
@@ -226,7 +225,7 @@ class ProcrastinationDetectorService : Service(), SensorEventListener {
          */
         fun stop(caller: Context) = performStartStopAction(caller, STOP_ACTION)
 
-        private fun performStartStopAction(caller: Context, action: String){
+        private fun performStartStopAction(caller: Context, action: String) {
             val intent = Intent(caller, ProcrastinationDetectorService::class.java)
             intent.action = action
             caller.startForegroundService(intent)

--- a/app/src/main/java/com/github/multimatum_team/multimatum/service/ProcrastinationDetectorService.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/service/ProcrastinationDetectorService.kt
@@ -17,6 +17,7 @@ import com.github.multimatum_team.multimatum.MainSettingsActivity
 import com.github.multimatum_team.multimatum.R
 import com.github.multimatum_team.multimatum.service.ProcrastinationDetectorService.Companion.NOTIFICATION_CHANNEL_ID
 import dagger.hilt.android.AndroidEntryPoint
+import java.lang.IllegalArgumentException
 import javax.inject.Inject
 import kotlin.math.abs
 
@@ -50,7 +51,7 @@ class ProcrastinationDetectorService : Service(), SensorEventListener {
             when (val action = intent.action) {
                 START_ACTION -> if (!isServiceStarted) startProcrastinationDetectorService()
                 STOP_ACTION -> stopProcrastinationDetectorService()
-                else -> throw IllegalStateException("unexpected action: $action")
+                else -> throw IllegalArgumentException("unexpected action: $action")
             }
         }
         return START_STICKY  // service must restart as soon as possible if preempted

--- a/app/src/main/java/com/github/multimatum_team/multimatum/service/ProcrastinationDetectorService.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/service/ProcrastinationDetectorService.kt
@@ -92,7 +92,7 @@ class ProcrastinationDetectorService : Service(), SensorEventListener {
         }
     }
 
-    private fun stopProcrastinationDetectorService() {
+    fun stopProcrastinationDetectorService() {
         unregisterServiceFromSensorListeners()
         toast(getString(R.string.procrastination_fighter_disabled_msg))
         releaseWakeLock()

--- a/app/src/main/java/com/github/multimatum_team/multimatum/service/ProcrastinationDetectorService.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/service/ProcrastinationDetectorService.kt
@@ -63,6 +63,9 @@ class ProcrastinationDetectorService : Service(), SensorEventListener {
 
     override fun onDestroy() {
         super.onDestroy()
+        val stopIntent = Intent(applicationContext, ProcrastinationDetectorService::class.java)
+        stopIntent.action = STOP_ACTION
+        onStartCommand(stopIntent, 0, 0)
         Log.d(LOG_TAG, "Service destroyed")
     }
 
@@ -90,7 +93,7 @@ class ProcrastinationDetectorService : Service(), SensorEventListener {
         }
     }
 
-    fun stopProcrastinationDetectorService() {
+    private fun stopProcrastinationDetectorService() {
         unregisterServiceFromSensorListeners()
         toast(getString(R.string.procrastination_fighter_disabled_msg))
         releaseWakeLock()

--- a/app/src/main/java/com/github/multimatum_team/multimatum/service/ProcrastinationDetectorService.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/service/ProcrastinationDetectorService.kt
@@ -206,9 +206,9 @@ class ProcrastinationDetectorService : Service(), SensorEventListener {
         private const val NOTIFICATION_CHANNEL_ID =
             "com.github.multimatum_team-mutlimatum.ProcrastinationDetectorServiceChannel"
 
-        private const val START_ACTION =
+        const val START_ACTION =
             "com.github.multimatum_team.multimatum.StartProcrastinationDetectorServiceAction"
-        private const val STOP_ACTION =
+        const val STOP_ACTION =
             "com.github.multimatum_team.multimatum.StopProcrastinationDetectorServiceAction"
 
         private const val FOREGROUND_SERVICE_NOTIF_ID = 1

--- a/app/src/main/java/com/github/multimatum_team/multimatum/service/ProcrastinationDetectorService.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/service/ProcrastinationDetectorService.kt
@@ -15,7 +15,6 @@ import android.util.Log
 import android.widget.Toast
 import com.github.multimatum_team.multimatum.MainSettingsActivity
 import com.github.multimatum_team.multimatum.R
-import com.github.multimatum_team.multimatum.service.ProcrastinationDetectorService.Companion.NOTIFICATION_CHANNEL_ID
 import dagger.hilt.android.AndroidEntryPoint
 import java.lang.IllegalArgumentException
 import javax.inject.Inject
@@ -219,19 +218,17 @@ class ProcrastinationDetectorService : Service(), SensorEventListener {
          * Launches ProcrastinationDetectorService
          * @param caller should be 'this' in the calling activity
          */
-        fun launch(caller: Context) {
-            val intent = Intent(caller, ProcrastinationDetectorService::class.java)
-            intent.action = START_ACTION
-            caller.startForegroundService(intent)
-        }
+        fun launch(caller: Context) = performStartStopAction(caller, START_ACTION)
 
         /**
          * Stops ProcrastinationDetectorService
          * @param caller should be 'this' in the calling activity
          */
-        fun stop(caller: Context) {
+        fun stop(caller: Context) = performStartStopAction(caller, STOP_ACTION)
+
+        private fun performStartStopAction(caller: Context, action: String){
             val intent = Intent(caller, ProcrastinationDetectorService::class.java)
-            intent.action = STOP_ACTION
+            intent.action = action
             caller.startForegroundService(intent)
         }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -29,6 +29,8 @@
     <string name="logout">LOGOUT</string>
     <string name="procrastination_fighter_enable_msg">Procrastination fighter is enabled</string>
     <string name="procrastination_fighter_disabled_msg">Procrastination fighter is disabled</string>
+    <string name="procrastination_fighter_permanent_notif_title">Procrastination detector</string>
+    <string name="procrastination_fighter_permanent_notif_content_text">Procrastination is bad...</string>
     <string name="deleted">Deleted</string>
     <string name="undo">Undo</string>
     <string name="write_title_here">Write Title here</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,7 +2,7 @@
     <string name="app_name">multimatum</string>
     <string name="log_in_text">Log in</string>
     <string name="qr_code_scanner_button_text">Scanner</string>
-    <string name="calendar_deadline_input_text">Enter new deadline...</string>
+    <string name="calendar_deadline_input_text">Enter new deadline…</string>
     <string name="calender_add_new_deadline_button_text">Add</string>
     <string name="calendar_button_text">Calendar</string>
     <string name="main_settings_activity_title">Settings</string>
@@ -30,7 +30,7 @@
     <string name="procrastination_fighter_enable_msg">Procrastination fighter is enabled</string>
     <string name="procrastination_fighter_disabled_msg">Procrastination fighter is disabled</string>
     <string name="procrastination_fighter_permanent_notif_title">Procrastination detector</string>
-    <string name="procrastination_fighter_permanent_notif_content_text">Procrastination is bad...</string>
+    <string name="procrastination_fighter_permanent_notif_content_text">Procrastination is bad…</string>
     <string name="deleted">Deleted</string>
     <string name="undo">Undo</string>
     <string name="write_title_here">Write Title here</string>

--- a/app/src/test/java/com/github/multimatum_team/multimatum/service/ProcrastinationDetectorServiceTest.kt
+++ b/app/src/test/java/com/github/multimatum_team/multimatum/service/ProcrastinationDetectorServiceTest.kt
@@ -19,7 +19,8 @@ import dagger.hilt.android.testing.HiltAndroidTest
 import dagger.hilt.android.testing.UninstallModules
 import dagger.hilt.components.SingletonComponent
 import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.*
+import org.hamcrest.Matchers.`is`
+import org.hamcrest.Matchers.equalTo
 import org.junit.After
 import org.junit.Assert.assertThrows
 import org.junit.Assert.fail
@@ -35,7 +36,6 @@ import org.mockito.kotlin.mock
 import org.robolectric.Robolectric
 import org.robolectric.RuntimeEnvironment
 import org.robolectric.shadows.ShadowToast
-import java.lang.IllegalArgumentException
 import javax.inject.Singleton
 
 @UninstallModules(DependenciesProvider::class)

--- a/app/src/test/java/com/github/multimatum_team/multimatum/service/ProcrastinationDetectorServiceTest.kt
+++ b/app/src/test/java/com/github/multimatum_team/multimatum/service/ProcrastinationDetectorServiceTest.kt
@@ -1,5 +1,6 @@
 package com.github.multimatum_team.multimatum.service
 
+import android.content.Context
 import android.content.Intent
 import android.content.SharedPreferences
 import android.hardware.Sensor
@@ -22,8 +23,7 @@ import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.`is`
 import org.hamcrest.Matchers.equalTo
 import org.junit.After
-import org.junit.Assert.assertThrows
-import org.junit.Assert.fail
+import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -231,6 +231,33 @@ class ProcrastinationDetectorServiceTest {
             service.onSensorChanged(mockSensorEvent)
         }
         destroyTestServiceController(controller)
+    }
+
+    @Test
+    fun launch_should_call_startForegroundService_with_start_action(){
+        launchStopTest(ProcrastinationDetectorService.START_ACTION){
+            ProcrastinationDetectorService.launch(it)
+        }
+    }
+
+    @Test
+    fun stop_should_call_startForegroundService_with_stop_action(){
+        launchStopTest(ProcrastinationDetectorService.STOP_ACTION){
+            ProcrastinationDetectorService.stop(it)
+        }
+    }
+
+    // common function for the tests of launch and stop
+    private fun launchStopTest(expectedIntentAction: String, functionToTest: (Context) -> Unit){
+        val mockCaller: Context = mock()
+        var actualIntent: Intent? = null
+        `when`(mockCaller.startForegroundService(any())).then {
+            actualIntent = it.getArgument(0)
+            null
+        }
+        functionToTest(mockCaller)
+        assertNotNull(actualIntent)
+        assertThat(actualIntent!!.action, `is`(expectedIntentAction))
     }
 
     private fun createTestServiceController(): ServiceController<ProcrastinationDetectorService> {

--- a/app/src/test/java/com/github/multimatum_team/multimatum/service/ProcrastinationDetectorServiceTest.kt
+++ b/app/src/test/java/com/github/multimatum_team/multimatum/service/ProcrastinationDetectorServiceTest.kt
@@ -160,7 +160,7 @@ class ProcrastinationDetectorServiceTest {
     @Test
     fun onStartCommand_throws_when_sensor_not_found() {
         `when`(mockSensorManager.getDefaultSensor(any())).thenReturn(null)
-        assertThrows(IllegalStateException::class.java) {
+        assertThrows(IllegalArgumentException::class.java) {
             controller.create().startCommand(0, 0)
         }
         controller.destroy()


### PR DESCRIPTION
Procrastination detector now also works when the app is swiped out. It uses a foreground service for that, so a notification is displayed as long as the service is active.

This feature is still experimental, the detection is currently too sensitive to be usable, but this will be adjusted in future sprint(s). In particular we will need to let the user access Multimatum without being harassed by injunctions to start working...

Closes #102