### PR TITLE
Logging/disable logging when not debug

### DIFF
--- a/app/src/debug/java/com/github/multimatum_team/multimatum/LogUtilImpl.kt
+++ b/app/src/debug/java/com/github/multimatum_team/multimatum/LogUtilImpl.kt
@@ -1,0 +1,54 @@
+package com.github.multimatum_team.multimatum
+
+import android.util.Log
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Debug implementation of LogUtil functions
+ */
+object LogUtilImpl: LogUtil.FunctionsProvider {
+
+    override fun debugLog(str: String) = safeExec {
+        val currFunc = Thread.currentThread().stackTrace[STACK_IDX_FOR_ENV_FUNC]
+        Log.d(createTag(currFunc), str)
+    }
+
+    override fun logFunctionCall() = safeExec {
+        val currFunc = Thread.currentThread().stackTrace[STACK_IDX_FOR_ENV_FUNC]
+        val msg = "${currFunc.methodName} called"
+        Log.d(createTag(currFunc), msg)
+    }
+
+    override fun logFunctionCall(str: String) = safeExec {
+        val currFunc = Thread.currentThread().stackTrace[STACK_IDX_FOR_ENV_FUNC]
+        val msg = "${currFunc.methodName} called: $str"
+        Log.d(createTag(currFunc), msg)
+    }
+
+    private fun safeExec(task: () -> Unit) {
+        try {
+            task()
+        } catch (throwable: Throwable) {
+            Log.d(TAG, "logging failed")
+        }
+    }
+
+    // creates a tag with the class name of the given stack element
+    private fun createTag(currFunc: StackTraceElement): String =
+        "${Counter.next()} ${simpleNameOf(currFunc.className)}"
+
+    // extracts the simple name from a complete class name
+    private fun simpleNameOf(name: String): String = name.takeLastWhile { it != '.' }
+
+    private const val TAG = "DebugUtil"
+
+    // index in the stack to find the environment function
+    private const val STACK_IDX_FOR_ENV_FUNC = 6
+
+    // counter for the indexing of logging events
+    private object Counter {
+        private val atomicInteger = AtomicInteger(0)
+        fun next() = atomicInteger.incrementAndGet()
+    }
+
+}

--- a/app/src/debug/java/com/github/multimatum_team/multimatum/LogUtilImpl.kt
+++ b/app/src/debug/java/com/github/multimatum_team/multimatum/LogUtilImpl.kt
@@ -4,7 +4,10 @@ import android.util.Log
 import java.util.concurrent.atomic.AtomicInteger
 
 /**
- * Debug implementation of LogUtil functions
+ * Debug implementation of LogUtil functions <p>
+ * This file is used in debug builds to perform logging,
+ * but it should not be used in release builds because calls
+ * to reflection methods are uselessly costly
  */
 object LogUtilImpl: LogUtil.FunctionsProvider {
 

--- a/app/src/main/java/com/github/multimatum_team/multimatum/LogUtil.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/LogUtil.kt
@@ -11,6 +11,14 @@ object LogUtil {
 
     private val instance = LogUtilImpl
 
+    /*
+     * To add a new method to this class:
+     * 1. declare it in FunctionsProvider
+     * 2. declare it in LogUtil, with an implementation that simply calls the method on `instance`
+     * 3. implement it in app/src/debug/java/com/github/multimatum_team/multimatum/LogUtilImpl.kt
+     * 4. implement it as a call to doNothing in app/src/release/java/com/github/multimatum_team/multimatum/LogUtilImpl.kt
+     */
+
     /**
      * Displays the message in the logs with level 'debug', inferring the tag
      */

--- a/app/src/main/java/com/github/multimatum_team/multimatum/LogUtil.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/LogUtil.kt
@@ -1,8 +1,5 @@
 package com.github.multimatum_team.multimatum
 
-import android.util.Log
-import java.util.concurrent.atomic.AtomicInteger
-
 /**
  * Enhanced logging methods
  *
@@ -12,57 +9,40 @@ import java.util.concurrent.atomic.AtomicInteger
  */
 object LogUtil {
 
+    private val instance = LogUtilImpl
+
     /**
      * Displays the message in the logs with level 'debug', inferring the tag
      */
-    fun debugLog(str: String) = safeExec {
-        val currFunc = Thread.currentThread().stackTrace[STACK_IDX_FOR_ENV_FUNC]
-        Log.d(createTag(currFunc), str)
-    }
+    fun debugLog(str: String) = instance.debugLog(str)
 
     /**
      * Reports that the function in which it is called has been called
      */
-    fun logFunctionCall() = safeExec {
-        val currFunc = Thread.currentThread().stackTrace[STACK_IDX_FOR_ENV_FUNC]
-        val msg = "${currFunc.methodName} called"
-        Log.d(createTag(currFunc), msg)
-    }
+    fun logFunctionCall() = instance.logFunctionCall()
 
     /**
      * Reports that the function in which it is called has been called, and displays
      * the given message
      */
-    fun logFunctionCall(str: String) = safeExec {
-        val currFunc = Thread.currentThread().stackTrace[STACK_IDX_FOR_ENV_FUNC]
-        val msg = "${currFunc.methodName} called: $str"
-        Log.d(createTag(currFunc), msg)
-    }
+    fun logFunctionCall(str: String) = instance.logFunctionCall(str)
 
-    private fun safeExec(task: () -> Unit) {
-        try {
-            task()
-        } catch (throwable: Throwable) {
-            Log.d(TAG, "logging failed")
-        }
-    }
+    interface FunctionsProvider {
+        /**
+         * Displays the message in the logs with level 'debug', inferring the tag
+         */
+        fun debugLog(str: String)
 
-    // creates a tag with the class name of the given stack element
-    private fun createTag(currFunc: StackTraceElement): String =
-        "${Counter.next()} ${simpleNameOf(currFunc.className)}"
+        /**
+         * Reports that the function in which it is called has been called
+         */
+        fun logFunctionCall()
 
-    // extracts the simple name from a complete class name
-    private fun simpleNameOf(name: String): String = name.takeLastWhile { it != '.' }
-
-    private const val TAG = "DebugUtil"
-
-    // index in the stack to find the environment function
-    private const val STACK_IDX_FOR_ENV_FUNC = 6
-
-    // counter for the indexing of logging events
-    private object Counter {
-        private val atomicInteger = AtomicInteger(0)
-        fun next() = atomicInteger.incrementAndGet()
+        /**
+         * Reports that the function in which it is called has been called, and displays
+         * the given message
+         */
+        fun logFunctionCall(str: String)
     }
 
 }

--- a/app/src/release/java/com/github/multimatum_team/multimatum/LogUtilImpl.kt
+++ b/app/src/release/java/com/github/multimatum_team/multimatum/LogUtilImpl.kt
@@ -1,0 +1,16 @@
+package com.github.multimatum_team.multimatum
+
+/**
+ * Release implementation of LogUtil functions (do nothing in release mode)
+ */
+class LogUtilImpl: LogUtil.FunctionsProvider {
+
+    override fun debugLog(str: String) = doNothing()
+
+    override fun logFunctionCall() = doNothing()
+
+    override fun logFunctionCall(str: String) = doNothing()
+
+    private fun doNothing() { }
+
+}

--- a/app/src/release/java/com/github/multimatum_team/multimatum/LogUtilImpl.kt
+++ b/app/src/release/java/com/github/multimatum_team/multimatum/LogUtilImpl.kt
@@ -1,7 +1,9 @@
 package com.github.multimatum_team.multimatum
 
 /**
- * Release implementation of LogUtil functions (do nothing in release mode)
+ * Release implementation of LogUtil functions (do nothing in release mode) <p>
+ * This file is used in the release builds. The methods simply do nothing
+ * because logging is not needed in a release version of the app.
  */
 object LogUtilImpl: LogUtil.FunctionsProvider {
 

--- a/app/src/release/java/com/github/multimatum_team/multimatum/LogUtilImpl.kt
+++ b/app/src/release/java/com/github/multimatum_team/multimatum/LogUtilImpl.kt
@@ -3,7 +3,7 @@ package com.github.multimatum_team.multimatum
 /**
  * Release implementation of LogUtil functions (do nothing in release mode)
  */
-class LogUtilImpl: LogUtil.FunctionsProvider {
+object LogUtilImpl: LogUtil.FunctionsProvider {
 
     override fun debugLog(str: String) = doNothing()
 


### PR DESCRIPTION
The methods in `LogUtil` involve reflection and must perform a few operations before being able to log something. Therefore, it is better for efficiency to disable them when building the release version of the app. This is implemented using two versions of `LogUtilImpl`, one in the `debug` directory that does actual logging, and another version in the `release` directory that does nothing. Methods in `LogUtil` simply call the equivalent method in the version of `LogUtilImpl` that has been included in the build.