### PR TITLE
Feature/date time recognition

### DIFF
--- a/app/src/main/java/com/github/multimatum_team/multimatum/model/datetime_parser/DateTimeExtractor.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/model/datetime_parser/DateTimeExtractor.kt
@@ -6,46 +6,138 @@ import java.util.*
 object DateTimeExtractor {
 
     /*
+        TODO implement date recognition + more patterns for time recognition
+
         When finished, should be able to parse:
 
         18h00
         18h
         6am
         6pm
+        etc.
 
         Monday
         next Monday
         on Monday
+        etc.
      */
 
     private fun List<Any?>.getInt(idx: Int): Int = get(idx) as Int
 
+    /**
+     * Time information extracted from a string
+     * Can be a date, a time or NoInfo if no info was found
+     */
     private sealed interface ExtractedInfo
     private data class ExtractedDate(val date: Date) : ExtractedInfo
     private data class ExtractedTime(val time: LocalTime) : ExtractedInfo
     private object NoInfo : ExtractedInfo
 
+
+    // WARNING: you are about to read one of the most complicated pieces of code of this project
+    // DISCLAIMER: this would not be necessary if Kotlin implemented pattern matching properly...
+    /**
+     * All the patterns that the parser should recognize
+     *
+     * Implemented as a list of pairs where the first element is an "extractor", a list of functions
+     * that map a token to any kind of value. This list is applied to the beginning of a list of
+     * tokens by applying the function at index i to the token at index i in the list. A pattern is
+     * considered to match the beginning of the list iff all of these function applications return
+     * something else than null. If it matches, the (non-null) results of these function applications
+     * are used to build a list that is given as an argument to the second element of the pair, that
+     * should use it to build an appropriate ExtractedInfo
+     *
+     * e.g.: for the pair
+     *
+     *    listOf(
+     *        Token::asHour,
+     *        { it.filterEqualTo(":") },
+     *        Token::asMinute
+     *    ) to { args: List<Any?> ->
+     *        ExtractedTime(LocalTime.of(args.getInt(0), args.getInt(2)))
+     *    }
+     *
+     * the pattern
+     *
+     *    listOf(
+     *       Token::asHour,
+     *       { it.filterEqualTo(":") },
+     *       Token::asMinute
+     *    )
+     *
+     * matches the list
+     *
+     *     listOf(NumericToken("15"), SymbolToken(":"), NumericToken("00"))
+     *
+     * (obtained by tokenizing the string 15:00)
+     *
+     * because asHour returns 15, filterEqualTo returns a non-null value (the SymbolToken itself) and
+     * asMinute returns 0.
+     * Then the "extractor"
+     *
+     *     args: List<Any?> -> ExtractedTime(LocalTime.of(args.getInt(0), args.getInt(2)))
+     *
+     * is applied to the list [15, SymbolToken(":"), 0] and builds an ExtractedTime that contains
+     * the time 15:00
+     */
     private val PATTERNS: List<Pair<List<(Token) -> Any?>, (List<Any?>) -> ExtractedInfo>> = listOf(
-        listOf(Token::asHour, { it.filterEqualTo(":") }, Token::asMinute) to
-                { args: List<Any?> -> ExtractedTime(LocalTime.of(args.getInt(0), args.getInt(2))) },
-        listOf({ it.filterEqualTo("at") }, Token::filterWhitespace, Token::asHour, { it.filterEqualTo(":") }, Token::asMinute) to
-                { args: List<Any?> -> ExtractedTime(LocalTime.of(args.getInt(2), args.getInt(4))) },
-        listOf(Token::asHour, { it.filterEqualTo("am") }) to
-                { args: List<Any?> -> ExtractedTime(LocalTime.of(args.getInt(0), 0)) },
-        listOf(Token::asHour, { it.filterEqualTo("pm") }) to
-                { args: List<Any?> -> ExtractedTime(LocalTime.of(args.getInt(0) + 12, 0)) }
+        listOf(
+            Token::asHour,
+            { it.filterEqualTo(":") },
+            Token::asMinute
+        ) to { args: List<Any?> ->
+            ExtractedTime(LocalTime.of(args.getInt(0), args.getInt(2)))
+        },
+        listOf(
+            { it.filterEqualTo("at") },
+            Token::filterWhitespace,
+            Token::asHour,
+            { it.filterEqualTo(":") },
+            Token::asMinute
+        ) to { args: List<Any?> ->
+            ExtractedTime(LocalTime.of(args.getInt(2), args.getInt(4)))
+        },
+        listOf(
+            Token::asHour,
+            { it.filterEqualTo("am") }
+        ) to { args: List<Any?> ->
+            ExtractedTime(LocalTime.of(args.getInt(0), 0))
+        },
+        listOf(
+            Token::asHour,
+            { it.filterEqualTo("pm") }
+        ) to { args: List<Any?> ->
+            ExtractedTime(LocalTime.of(args.getInt(0) + 12, 0))
+        }
     )
 
+    /**
+     * Analyzes the given string and uses the patterns above to extract date or time info
+     * @return a DateTimeExtractionResult, containing:
+     * - the title after removing the date and time info
+     * - the extracted date, if any was found
+     * - the extracted time, if any was found
+     */
     fun parse(str: String): DateTimeExtractionResult {
 
+        // this list will be filled with the tokens that do not provide info on date/time
         val alreadyProcessedTokensWithoutTimeInfo = mutableListOf<Token>()
 
+        /**
+         * Return value of extractDateTimeInfo
+         * @param extractedInfo Time information extracted from the string
+         * @param remaining tokens that remain to be processed (tail of the initial tokens list)
+         * @param consumed the tokens corresponding to the extracted info (first elements of the tokens list)
+         */
         data class ExtractionResult(
             val extractedInfo: ExtractedInfo,
             val remaining: List<Token>,
             val consumed: List<Token>
         )
 
+        /**
+         * Attempts to match each of the patterns with the beginning of the list
+         */
         fun extractDateTimeInfo(tokens: List<Token>): ExtractionResult {
             require(tokens.isNotEmpty())
             return PATTERNS.asSequence()
@@ -65,17 +157,21 @@ object DateTimeExtractor {
                 } ?: ExtractionResult(NoInfo, tokens.drop(1), tokens.subList(0, 1))
         }
 
+        /**
+         * Iterates on the list of tokens
+         */
         tailrec fun recurse(
             remTokens: List<Token>,
             date: Date?,
             time: LocalTime?
         ): Pair<Date?, LocalTime?> =
             if (remTokens.isEmpty()) {
-                Pair(date, time)
+                Pair(date, time)  // end of list, return found info
             } else {
                 val (extractedInfo, newRemTokens, consumed) = extractDateTimeInfo(remTokens)
                 when (extractedInfo) {
                     is ExtractedDate -> {
+                        // if a date has already been found, ignore the newly found one (treat it as normal text)
                         val newDate = date ?: extractedInfo.date
                         if (date != null) {
                             alreadyProcessedTokensWithoutTimeInfo.addAll(consumed)
@@ -83,6 +179,7 @@ object DateTimeExtractor {
                         recurse(newRemTokens, newDate, time)
                     }
                     is ExtractedTime -> {
+                        // if a time has already been found, ignore the newly found one (treat it as normal text)
                         val newTime = time ?: extractedInfo.time
                         if (time != null) {
                             alreadyProcessedTokensWithoutTimeInfo.addAll(consumed)
@@ -96,17 +193,17 @@ object DateTimeExtractor {
                 }
             }
 
+        // replaces the multiple whitespaces (e.g. "     ") by a single whitespace
         fun removeMultipleWhitespaces(str: String): String =
-            if (str.contains("  ", ignoreCase = true)){
+            if (str.contains("  ", ignoreCase = true)) {
                 removeMultipleWhitespaces(str.replace("  ", " ", ignoreCase = true))
-            }
-            else str
+            } else str
 
         val initTokens = Tokenizer.tokenize(str)
         val (date, time) = recurse(initTokens, null, null)
         val text = alreadyProcessedTokensWithoutTimeInfo
-            .dropWhile { it is WhitespaceToken }
-            .dropLastWhile { it is WhitespaceToken }
+            .dropWhile { it is WhitespaceToken }     // ignore leading whitespaces
+            .dropLastWhile { it is WhitespaceToken } // ignore trailing whitespaces
             .joinToString(separator = "", transform = Token::str)
             .let(::removeMultipleWhitespaces)
         return DateTimeExtractionResult(text, date, time)
@@ -114,6 +211,12 @@ object DateTimeExtractor {
 
 }
 
+/**
+ * Contains the info extracted by parsing
+ * @param text the text after removing the parts that contain time/date info
+ * @param date the date found in the initial text, if any was found
+ * @param time the time found in the initial text if any was found
+ */
 data class DateTimeExtractionResult(
     val text: String,
     val date: Date? = null,

--- a/app/src/main/java/com/github/multimatum_team/multimatum/model/datetime_parser/DateTimeExtractor.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/model/datetime_parser/DateTimeExtractor.kt
@@ -1,0 +1,47 @@
+package com.github.multimatum_team.multimatum.model.datetime_parser
+
+import java.time.LocalTime
+import java.util.*
+
+object DateTimeExtractor {
+
+    /*
+    18h00
+    18h
+    6am
+    6pm
+
+    Monday
+    next Monday
+    on Monday
+     */
+
+    private val PATTERNS = listOf<List<(Token) -> Boolean>>(
+        listOf(Token::isHour, { it.isEqualTo(":") }, Token::isMinute),
+        TODO()
+    )
+
+    fun parse(str: String): DateTimeExtractionResult {
+
+        val remainingTokens = Tokenizer.tokenize(str).toMutableList()
+        val alreadyProcessedTokensWithoutTimeInfo = mutableListOf<Token>()
+
+        tailrec fun extractDateTimeInfo(date: Date?, time: LocalTime?): Pair<Date?, LocalTime?> {
+            TODO()
+        }
+
+        val (date, time) = extractDateTimeInfo(null, null)
+        val text = alreadyProcessedTokensWithoutTimeInfo.joinToString { it.str }
+        return DateTimeExtractionResult(text, date, time)
+    }
+
+}
+
+data class DateTimeExtractionResult(
+    val text: String,
+    val date: Date? = null,
+    val time: LocalTime? = null
+) {
+    val dateFound get() = (date != null)
+    val timeFound get() = (time != null)
+}

--- a/app/src/main/java/com/github/multimatum_team/multimatum/model/datetime_parser/DateTimeExtractor.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/model/datetime_parser/DateTimeExtractor.kt
@@ -16,25 +16,96 @@ object DateTimeExtractor {
     on Monday
      */
 
-    private val PATTERNS = listOf<List<(Token) -> Boolean>>(
-        listOf(Token::isHour, { it.isEqualTo(":") }, Token::isMinute),
-        TODO()
+    private fun List<Any?>.getInt(idx: Int): Int = get(idx) as Int
+
+    private sealed interface ExtractedInfo
+    private data class ExtractedDate(val date: Date) : ExtractedInfo
+    private data class ExtractedTime(val time: LocalTime) : ExtractedInfo
+    private object NoInfo : ExtractedInfo
+
+    private val PATTERNS: List<Pair<List<(Token) -> Any?>, (List<Any?>) -> ExtractedInfo>> = listOf(
+        listOf(Token::asHour, { it.filterEqualTo(":") }, Token::asMinute) to
+                { args: List<Any?> -> ExtractedTime(LocalTime.of(args.getInt(0), args.getInt(2))) }
     )
 
     fun parse(str: String): DateTimeExtractionResult {
 
-        val remainingTokens = Tokenizer.tokenize(str).toMutableList()
         val alreadyProcessedTokensWithoutTimeInfo = mutableListOf<Token>()
 
-        tailrec fun extractDateTimeInfo(date: Date?, time: LocalTime?): Pair<Date?, LocalTime?> {
-            TODO()
+        data class ExtractionResult(
+            val extractedInfo: ExtractedInfo,
+            val remaining: List<Token>,
+            val consumed: List<Token>
+        )
+
+        fun extractDateTimeInfo(tokens: List<Token>): ExtractionResult {
+            require(tokens.isNotEmpty())
+            return PATTERNS.asSequence()
+                .filter { (extractors, _) -> extractors.size <= tokens.size }
+                .map { (extractors, createExtractedInfo) ->
+                    val curr = tokens.take(extractors.size)
+                    val next = tokens.drop(extractors.size)
+                    Triple(
+                        extractors.zip(curr).map { (extr, tok) -> extr(tok) },
+                        createExtractedInfo,
+                        Pair(next, curr)
+                    )
+                }
+                .find { (args, _, _) -> args.all { it != null } }
+                ?.let { (args, createExtracted, nextAndCurr) ->
+                    ExtractionResult(createExtracted(args), nextAndCurr.first, nextAndCurr.second)
+                } ?: ExtractionResult(NoInfo, tokens.drop(1), tokens.subList(0, 1))
         }
 
-        val (date, time) = extractDateTimeInfo(null, null)
-        val text = alreadyProcessedTokensWithoutTimeInfo.joinToString { it.str }
+        tailrec fun recurse(
+            remTokens: List<Token>,
+            date: Date?,
+            time: LocalTime?
+        ): Pair<Date?, LocalTime?> =
+            if (remTokens.isEmpty()) {
+                Pair(date, time)
+            } else {
+                val (extractedInfo, newRemTokens, consumed) = extractDateTimeInfo(remTokens)
+                when (extractedInfo) {
+                    is ExtractedDate -> {
+                        val newDate = date ?: extractedInfo.date
+                        if (date != null) {
+                            alreadyProcessedTokensWithoutTimeInfo.addAll(consumed)
+                        }
+                        recurse(newRemTokens, newDate, time)
+                    }
+                    is ExtractedTime -> {
+                        val newTime = time ?: extractedInfo.time
+                        if (time != null) {
+                            alreadyProcessedTokensWithoutTimeInfo.addAll(consumed)
+                        }
+                        recurse(newRemTokens, date, newTime)
+                    }
+                    is NoInfo -> {
+                        alreadyProcessedTokensWithoutTimeInfo.addAll(consumed)
+                        recurse(newRemTokens, date, time)
+                    }
+                }
+            }
+
+        val initTokens = Tokenizer.tokenize(str)
+        val (date, time) = recurse(initTokens, null, null)
+        val text = alreadyProcessedTokensWithoutTimeInfo
+            .dropWhile { it is WhitespaceToken }
+            .dropLastWhile { it is WhitespaceToken }
+            .joinToString(separator = "", transform = Token::str)
         return DateTimeExtractionResult(text, date, time)
     }
 
+}
+
+enum class DayOfWeek {
+    MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY;
+
+    companion object {
+        fun parse(str: String): DayOfWeek? =
+            values().find { it.name.lowercase() == str.lowercase() }
+    }
 }
 
 data class DateTimeExtractionResult(

--- a/app/src/main/java/com/github/multimatum_team/multimatum/model/datetime_parser/Tokens.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/model/datetime_parser/Tokens.kt
@@ -1,0 +1,78 @@
+package com.github.multimatum_team.multimatum.model.datetime_parser
+
+sealed interface Token {
+
+    val str: String
+
+    fun isEqualTo(text: String) = (str == text)
+
+    fun isHour(): Boolean = false
+    fun isMinute(): Boolean = false
+
+}
+
+data class AlphabeticToken(override val str: String) : Token {
+
+}
+
+data class NumericToken(override val str: String) : Token {
+    init {
+        require(str.all(Char::isDigit))
+    }
+    val numericValue: Int get() = str.toInt()
+    override fun isHour(): Boolean = (numericValue in 0..23)
+    override fun isMinute(): Boolean = (numericValue in 0..59)
+}
+
+data class SymbolToken(override val str: String) : Token {
+    init {
+        require(str.length == 1)
+    }
+    val charValue: Char get() = str[0]
+}
+
+object WhitespaceToken : Token {
+    override val str = " "
+    override fun toString(): String = "WhitespaceToken"
+}
+
+object Tokenizer {
+
+    private val TOKEN_CREATION_FUNCS = listOf(
+        Char::isLetter to ::AlphabeticToken,
+        Char::isDigit to ::NumericToken,
+        Char::isWhitespace to { _: String -> WhitespaceToken }
+    )
+
+    fun tokenize(str: String): List<Token> {
+
+        val tokens = mutableListOf<Token>()
+
+        fun consume(rem: String): Pair<Token?, String> =
+            if (rem.isEmpty()) {
+                Pair(null, "")
+            } else {
+                val headChar = rem[0]
+                val (matchChar, createToken) = TOKEN_CREATION_FUNCS.find { (matchChar, _) ->
+                    matchChar(headChar)
+                } ?: Pair({ _: Char -> false }, ::SymbolToken)
+                val tailChars = rem.substring(1)
+                val tokenTextTail = tailChars.takeWhile(matchChar)
+                val newRem = tailChars.dropWhile(matchChar)
+                val s = headChar + tokenTextTail
+                Pair(createToken(s), newRem)
+            }
+
+        tailrec fun tokenizeRemaining(rem: String) {
+            if (rem.isNotEmpty()) {
+                val (token, newRem) = consume(rem)
+                tokens.add(token!!)
+                tokenizeRemaining(newRem)
+            }
+        }
+
+        tokenizeRemaining(str)
+        return tokens
+    }
+
+}

--- a/app/src/main/java/com/github/multimatum_team/multimatum/model/datetime_parser/Tokens.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/model/datetime_parser/Tokens.kt
@@ -75,30 +75,30 @@ object Tokenizer {
     )
 
     /**
+     * @return a pair (leading token, rest of the string)
+     */
+    private fun extractLeadingToken(rem: String): Pair<Token?, String> =
+        if (rem.isEmpty()) {
+            Pair(null, "")
+        } else {
+            val headChar = rem[0]
+            val (matchChar, createToken) = TOKEN_CREATION_FUNCS.find { (matchChar, _) ->
+                matchChar(headChar)
+            } ?: Pair({ _: Char -> false }, ::SymbolToken)
+            val tailChars = rem.substring(1)
+            val tokenTextTail = tailChars.takeWhile(matchChar)
+            val newRem = tailChars.dropWhile(matchChar)
+            val s = headChar + tokenTextTail
+            Pair(createToken(s), newRem)
+        }
+
+    /**
      * Transforms the given string into a list of tokens that correspond to the type of characters
      * that they contain
      */
     fun tokenize(str: String): List<Token> {
 
         val tokens = mutableListOf<Token>()
-
-        /**
-         * @return a pair (leading token, rest of the string)
-         */
-        fun extractLeadingToken(rem: String): Pair<Token?, String> =
-            if (rem.isEmpty()) {
-                Pair(null, "")
-            } else {
-                val headChar = rem[0]
-                val (matchChar, createToken) = TOKEN_CREATION_FUNCS.find { (matchChar, _) ->
-                    matchChar(headChar)
-                } ?: Pair({ _: Char -> false }, ::SymbolToken)
-                val tailChars = rem.substring(1)
-                val tokenTextTail = tailChars.takeWhile(matchChar)
-                val newRem = tailChars.dropWhile(matchChar)
-                val s = headChar + tokenTextTail
-                Pair(createToken(s), newRem)
-            }
 
         /**
          * Iterates on the string and adds the tokens to the list

--- a/app/src/main/java/com/github/multimatum_team/multimatum/model/datetime_parser/Tokens.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/model/datetime_parser/Tokens.kt
@@ -4,10 +4,10 @@ sealed interface Token {
 
     val str: String
 
-    fun isEqualTo(text: String) = (str == text)
+    fun filterEqualTo(cmpStr: String): Token? = if (cmpStr == str) this else null
 
-    fun isHour(): Boolean = false
-    fun isMinute(): Boolean = false
+    fun asHour(): Int? = null
+    fun asMinute(): Int? = null
 
 }
 
@@ -20,8 +20,8 @@ data class NumericToken(override val str: String) : Token {
         require(str.all(Char::isDigit))
     }
     val numericValue: Int get() = str.toInt()
-    override fun isHour(): Boolean = (numericValue in 0..23)
-    override fun isMinute(): Boolean = (numericValue in 0..59)
+    override fun asHour(): Int? = if (numericValue in 0..23) numericValue else null
+    override fun asMinute(): Int? = if (numericValue in 0..59) numericValue else null
 }
 
 data class SymbolToken(override val str: String) : Token {

--- a/app/src/main/java/com/github/multimatum_team/multimatum/model/datetime_parser/Tokens.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/model/datetime_parser/Tokens.kt
@@ -5,15 +5,14 @@ sealed interface Token {
     val str: String
 
     fun filterEqualTo(cmpStr: String): Token? = if (cmpStr == str) this else null
+    fun filterWhitespace(): Token? = null
 
     fun asHour(): Int? = null
     fun asMinute(): Int? = null
 
 }
 
-data class AlphabeticToken(override val str: String) : Token {
-
-}
+data class AlphabeticToken(override val str: String) : Token
 
 data class NumericToken(override val str: String) : Token {
     init {
@@ -34,6 +33,7 @@ data class SymbolToken(override val str: String) : Token {
 object WhitespaceToken : Token {
     override val str = " "
     override fun toString(): String = "WhitespaceToken"
+    override fun filterWhitespace(): Token = this
 }
 
 object Tokenizer {

--- a/app/src/main/java/com/github/multimatum_team/multimatum/model/datetime_parser/Tokens.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/model/datetime_parser/Tokens.kt
@@ -7,11 +7,6 @@ sealed interface Token {
 
     val str: String
 
-    /**
-     * @return this if its str matches the provided one, null o.w.
-     */
-    fun filterEqualTo(cmpStr: String): Token? = if (cmpStr == str) this else null
-
     // The following methods are default implementations, they are meant to be overridden
     /**
      * @return this if it is a WhitespaceToken, null o.w.

--- a/app/src/test/java/com/github/multimatum_team/multimatum/DateTimeExtractorTest.kt
+++ b/app/src/test/java/com/github/multimatum_team/multimatum/DateTimeExtractorTest.kt
@@ -8,13 +8,46 @@ import java.time.LocalTime
 class DateTimeExtractorTest {
 
     @Test
-    fun date_is_extracted_correctly(){
+    fun time_is_extracted_correctly(){
         val str = "Aqua-pony at 10:00"
-        val expText = "Aqua-pony at"
+        val expText = "Aqua-pony"
         val actualRes = DateTimeExtractor.parse(str)
         assertEquals(expText, actualRes.text)
         assertTrue(actualRes.timeFound)
         assertEquals(LocalTime.of(10, 0), actualRes.time)
+        assertFalse(actualRes.dateFound)
+    }
+
+    @Test
+    fun am_time_is_parsed_correctly(){
+        val str = "Chemistry 2am (report)"
+        val expText = "Chemistry (report)"
+        val actualRes = DateTimeExtractor.parse(str)
+        assertEquals(expText, actualRes.text)
+        assertTrue(actualRes.timeFound)
+        assertEquals(LocalTime.of(2, 0), actualRes.time)
+        assertFalse(actualRes.dateFound)
+    }
+
+    @Test
+    fun pm_time_is_parsed_correctly(){
+        val str = "History dissertation 4pm"
+        val expText = "History dissertation"
+        val actualRes = DateTimeExtractor.parse(str)
+        assertEquals(expText, actualRes.text)
+        assertTrue(actualRes.timeFound)
+        assertEquals(LocalTime.of(16, 0), actualRes.time)
+        assertFalse(actualRes.dateFound)
+    }
+
+    @Test
+    fun second_time_is_ignored(){
+        val str = "History dissertation 4pm 5pm"
+        val expText = "History dissertation 5pm"
+        val actualRes = DateTimeExtractor.parse(str)
+        assertEquals(expText, actualRes.text)
+        assertTrue(actualRes.timeFound)
+        assertEquals(LocalTime.of(16, 0), actualRes.time)
         assertFalse(actualRes.dateFound)
     }
 

--- a/app/src/test/java/com/github/multimatum_team/multimatum/DateTimeExtractorTest.kt
+++ b/app/src/test/java/com/github/multimatum_team/multimatum/DateTimeExtractorTest.kt
@@ -1,0 +1,21 @@
+package com.github.multimatum_team.multimatum
+
+import com.github.multimatum_team.multimatum.model.datetime_parser.DateTimeExtractor
+import org.junit.Assert.*
+import org.junit.Test
+import java.time.LocalTime
+
+class DateTimeExtractorTest {
+
+    @Test
+    fun date_is_extracted_correctly(){
+        val str = "Aqua-pony at 10:00"
+        val expText = "Aqua-pony at"
+        val actualRes = DateTimeExtractor.parse(str)
+        assertEquals(expText, actualRes.text)
+        assertTrue(actualRes.timeFound)
+        assertEquals(LocalTime.of(10, 0), actualRes.time)
+        assertFalse(actualRes.dateFound)
+    }
+
+}

--- a/app/src/test/java/com/github/multimatum_team/multimatum/TokensTest.kt
+++ b/app/src/test/java/com/github/multimatum_team/multimatum/TokensTest.kt
@@ -1,0 +1,85 @@
+package com.github.multimatum_team.multimatum
+
+import com.github.multimatum_team.multimatum.model.datetime_parser.*
+import org.junit.Test
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import java.lang.IllegalArgumentException
+
+class TokensTest {
+
+    @Test
+    fun string_is_tokenized_correctly(){
+        val str = "abcd1234 !/xyz. 987"
+        val exp = listOf(
+            AlphabeticToken("abcd"),
+            NumericToken("1234"),
+            WhitespaceToken,
+            SymbolToken("!"),
+            SymbolToken("/"),
+            AlphabeticToken("xyz"),
+            SymbolToken("."),
+            WhitespaceToken,
+            NumericToken("987")
+        )
+        assertEquals(exp, Tokenizer.tokenize(str))
+    }
+
+    @Test
+    fun deadline_title_including_date_and_time_is_tokenized_correctly(){
+        val title = "Aqua-poney monday 15 at 11am"
+        val exp = listOf(
+            AlphabeticToken("Aqua"),
+            SymbolToken("-"),
+            AlphabeticToken("poney"),
+            WhitespaceToken,
+            AlphabeticToken("monday"),
+            WhitespaceToken,
+            NumericToken("15"),
+            WhitespaceToken,
+            AlphabeticToken("at"),
+            WhitespaceToken,
+            NumericToken("11"),
+            AlphabeticToken("am")
+        )
+        assertEquals(exp, Tokenizer.tokenize(title))
+    }
+
+    @Test
+    fun numericToken_gives_correct_numeric_value(){
+        val inputsOutputs = listOf(
+            "123" to 123,
+            "0" to 0,
+            "47" to 47
+        )
+        for ((input, output) in inputsOutputs){
+            assertEquals(output, NumericToken(input).numericValue)
+        }
+    }
+
+    @Test fun symbolToken_gives_correct_char_value(){
+        val inputsOutputs = listOf(
+            "!" to '!',
+            "*" to '*',
+            "@" to '@'
+        )
+        for ((input, output) in inputsOutputs){
+            assertEquals(output, SymbolToken(input).charValue)
+        }
+    }
+
+    @Test
+    fun numericToken_throws_on_non_numeric_input(){
+        assertThrows(IllegalArgumentException::class.java){
+            NumericToken("123a4")
+        }
+    }
+
+    @Test
+    fun symbolToken_throws_on_input_with_length_different_of_1(){
+        assertThrows(IllegalArgumentException::class.java){
+            SymbolToken("[!]")
+        }
+    }
+
+}


### PR DESCRIPTION
This PR contains the implementation of a parser that is intended to find date and time information in deadline titles. Currently it is able to parse time information, but not dates (this should be implemented in a future sprint). The parser first splits the string into tokens (more or less equivalent to words), and then tries to find a matching pattern among a list of patterns (implemented as functions). If a pattern is found, a time (or, in the future, a date) is created accordingly.

Currently only the logic is implemented, it is not actually linked to the app yet.

Closes #160