### PR TITLE
Feature/date time recognition continued

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -74,6 +74,7 @@ dependencies {
     implementation "androidx.activity:activity-ktx:1.4.0"
     implementation "androidx.fragment:fragment-ktx:1.4.1"
     implementation 'com.hudomju:swipe-to-dismiss-undo:1.0'
+    implementation 'net.yslibrary.keyboardvisibilityevent:keyboardvisibilityevent:3.0.0-RC2'
     kapt 'com.google.dagger:hilt-android-compiler:2.41'
     //noinspection LifecycleAnnotationProcessorWithJava8
     kapt 'androidx.lifecycle:lifecycle-compiler:2.4.1'

--- a/app/src/main/java/com/github/multimatum_team/multimatum/activity/AddDeadlineActivity.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/activity/AddDeadlineActivity.kt
@@ -61,13 +61,17 @@ class AddDeadlineActivity : AppCompatActivity() {
         KeyboardVisibilityEvent.setEventListener(this, object : KeyboardVisibilityEventListener {
             override fun onVisibilityChanged(isOpen: Boolean) {
                 if (!isOpen) {
-                    extractDateAndTimeIfAny()
+                    updateDisplayedInfoAfterTitleChange()
                 }
             }
         })
     }
 
-    private fun extractDateAndTimeIfAny() {
+    /**
+     * Analyses the title and tries to find date or time information,
+     * then uses it to update the displayed fields
+     */
+    private fun updateDisplayedInfoAfterTitleChange() {
         val dateTimeExtractionResult = dateTimeExtractor.parse(editText.text.toString())
         dateTimeExtractionResult.date?.also { foundDate ->
             selectedDate = selectedDate

--- a/app/src/main/java/com/github/multimatum_team/multimatum/model/datetime_parser/DateTimeExtractor.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/model/datetime_parser/DateTimeExtractor.kt
@@ -87,24 +87,17 @@ class DateTimeExtractor(private val dateTimePatterns: DateTimePatterns) {
             Pair(date, time)  // end of list, return found info
         } else {
             val (extractedInfo, newRemTokens, consumed) = extractDateTimeInfo(remTokens)
-            when (extractedInfo) {
-                is ExtractedDate -> {
-                    // if a date has already been found, ignore the newly found one (treat it as normal text)
-                    alreadyProcessedTokensList.addAll(if (date == null) listOf(RemovedToken) else consumed)
-                    val newDate = date ?: extractedInfo.date
-                    recursivelyParse(newRemTokens, newDate, time, alreadyProcessedTokensList)
-                }
-                is ExtractedTime -> {
-                    // if a time has already been found, ignore the newly found one (treat it as normal text)
-                    alreadyProcessedTokensList.addAll(if (time == null) listOf(RemovedToken) else consumed)
-                    val newTime = time ?: extractedInfo.time
-                    recursivelyParse(newRemTokens, date, newTime, alreadyProcessedTokensList)
-                }
-                is NoInfo -> {
-                    alreadyProcessedTokensList.addAll(consumed)
-                    recursivelyParse(newRemTokens, date, time, alreadyProcessedTokensList)
-                }
+            val newDate =
+                if (extractedInfo is ExtractedDate && date == null) extractedInfo.date else date
+            val newTime =
+                if (extractedInfo is ExtractedTime && time == null) extractedInfo.time else time
+            val newProcessedTokens = when (extractedInfo) {
+                is ExtractedDate -> if (date == null) listOf(RemovedToken) else consumed
+                is ExtractedTime -> if (time == null) listOf(RemovedToken) else consumed
+                is NoInfo -> consumed
             }
+            alreadyProcessedTokensList.addAll(newProcessedTokens)
+            recursivelyParse(newRemTokens, newDate, newTime, alreadyProcessedTokensList)
         }
 
     /**

--- a/app/src/main/java/com/github/multimatum_team/multimatum/model/datetime_parser/DateTimeExtractor.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/model/datetime_parser/DateTimeExtractor.kt
@@ -39,7 +39,9 @@ class DateTimeExtractor(private val dateTimePatterns: DateTimePatterns) {
      */
     private fun extractDateTimeInfo(tokens: List<Token>): ExtractionResult {
         require(tokens.isNotEmpty())
-        return dateTimePatterns.patterns.asSequence()
+        return dateTimePatterns.patterns
+            .sortedByDescending { it.first.size }
+            .asSequence()
             .filter { (pattern, _) -> pattern.size <= tokens.size }
             .map { (pattern, createExtractedInfoFunc) ->
                 val currentTokens = tokens.take(pattern.size)

--- a/app/src/main/java/com/github/multimatum_team/multimatum/model/datetime_parser/DateTimeExtractor.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/model/datetime_parser/DateTimeExtractor.kt
@@ -71,16 +71,10 @@ class DateTimeExtractor(private val dateTimePatternsGenerator: DateTimePatternsG
 
     /**
      * Applies the functions of the patterns to the corresponding tokens
-     * @return a sequence of triples, each containing:
-     *   1. the list of results of these function applications
-     *   2. the extractor corresponding to the pattern
-     *   3. a pair containing:
-     *      1) the tokens that remain to be consumed by the parser
-     *      2) the tokens that the were consumed by this pattern
      */
     private fun Sequence<PatternMatchCase>.matchTokensAgainstPattern(
         tokens: List<Token>
-    ) = map { (pattern, createExtractedInfoFunc) ->
+    ): Sequence<MatchingResult> = map { (pattern, createExtractedInfoFunc) ->
         val currentTokens = tokens.take(pattern.size)
         val nextTokens = tokens.drop(pattern.size)
         MatchingResult(

--- a/app/src/main/java/com/github/multimatum_team/multimatum/model/datetime_parser/DateTimeExtractor.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/model/datetime_parser/DateTimeExtractor.kt
@@ -82,9 +82,9 @@ class DateTimeExtractor(private val dateTimePatterns: DateTimePatterns) {
         date: LocalDate?,
         time: LocalTime?,
         alreadyProcessedTokensList: MutableList<Token>
-    ): Pair<LocalDate?, LocalTime?> =
+    ): Pair<LocalDate?, LocalTime?> {
         if (remTokens.isEmpty()) {
-            Pair(date, time)  // end of list, return found info
+            return Pair(date, time)  // end of list, return found info
         } else {
             val (extractedInfo, newRemTokens, consumed) = extractDateTimeInfo(remTokens)
             when (extractedInfo) {
@@ -92,20 +92,21 @@ class DateTimeExtractor(private val dateTimePatterns: DateTimePatterns) {
                     // if a date has already been found, ignore the newly found one (treat it as normal text)
                     alreadyProcessedTokensList.addAll(if (date == null) listOf(RemovedToken) else consumed)
                     val newDate = date ?: extractedInfo.date
-                    recursivelyParse(newRemTokens, newDate, time, alreadyProcessedTokensList)
+                    return recursivelyParse(newRemTokens, newDate, time, alreadyProcessedTokensList)
                 }
                 is ExtractedTime -> {
                     // if a time has already been found, ignore the newly found one (treat it as normal text)
                     alreadyProcessedTokensList.addAll(if (time == null) listOf(RemovedToken) else consumed)
                     val newTime = time ?: extractedInfo.time
-                    recursivelyParse(newRemTokens, date, newTime, alreadyProcessedTokensList)
+                    return recursivelyParse(newRemTokens, date, newTime, alreadyProcessedTokensList)
                 }
                 is NoInfo -> {
                     alreadyProcessedTokensList.addAll(consumed)
-                    recursivelyParse(newRemTokens, date, time, alreadyProcessedTokensList)
+                    return recursivelyParse(newRemTokens, date, time, alreadyProcessedTokensList)
                 }
             }
         }
+    }
 
     /**
      * Set followedByWhitespace to true for each token that is followed by a WhitespaceToken

--- a/app/src/main/java/com/github/multimatum_team/multimatum/model/datetime_parser/DateTimeExtractor.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/model/datetime_parser/DateTimeExtractor.kt
@@ -89,6 +89,9 @@ class DateTimeExtractor(private val dateTimePatterns: DateTimePatterns) {
             }
         }
 
+    /**
+     * Set followedByWhitespace to true for each token that is followed by a WhitespaceToken
+     */
     private fun markTokensFollowedByWhitespace(tokens: List<Token>) {
         tokens.fold(null as Token?) { prevTok, currTok ->
             if (currTok.isWhitespace()) {
@@ -101,7 +104,12 @@ class DateTimeExtractor(private val dateTimePatterns: DateTimePatterns) {
     private fun String.removeTrailingWhitespaces(): String =
         dropLastWhile { it.isWhitespace() }
 
-    private fun removeDanglingConjunctions(tokens: List<Token>): List<Token> {
+    /**
+     * Removes the conjunctions like "at", or "on" that are left after removal of date or time
+     * E.g. when parsing "Example at 10am", the "at" is not contained in the pattern, but should
+     * still be removed
+     */
+    private fun danglingConjunctionsRemoved(tokens: List<Token>): List<Token> {
         val remainingTokens = mutableListOf<Token>()
         val lastToken = tokens.fold(null as Token?) { prevTok, currTok ->
             if (prevTok != null
@@ -139,7 +147,7 @@ class DateTimeExtractor(private val dateTimePatterns: DateTimePatterns) {
             alreadyProcessedTokensWithoutTimeInfo
         )
         val text = alreadyProcessedTokensWithoutTimeInfo
-            .let(::removeDanglingConjunctions)
+            .let(::danglingConjunctionsRemoved)
             .joinToString(separator = "", transform = Token::strWithWhitespaceIfNeeded)
             .removeTrailingWhitespaces()
         return DateTimeExtractionResult(text, date, time)

--- a/app/src/main/java/com/github/multimatum_team/multimatum/model/datetime_parser/DateTimeExtractor.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/model/datetime_parser/DateTimeExtractor.kt
@@ -3,20 +3,18 @@ package com.github.multimatum_team.multimatum.model.datetime_parser
 import java.time.LocalDate
 import java.time.LocalTime
 
-object DateTimeExtractor {
+class DateTimeExtractor(private val dateTimePatterns: DateTimePatterns) {
+    constructor(currentDateProvider: () -> LocalDate) : this(DateTimePatterns(currentDateProvider))
 
 
     /*
         TODO implement date recognition + more patterns for time recognition
-
         When finished, should be able to parse:
-
         18h00
         18h
         6am
         6pm
         etc.
-
         Monday
         next Monday
         on Monday
@@ -41,7 +39,7 @@ object DateTimeExtractor {
      */
     private fun extractDateTimeInfo(tokens: List<Token>): ExtractionResult {
         require(tokens.isNotEmpty())
-        return DateTimePatterns.PATTERNS.asSequence()
+        return dateTimePatterns.patterns.asSequence()
             .filter { (pattern, _) -> pattern.size <= tokens.size }
             .map { (pattern, createExtractedInfoFunc) ->
                 val currentTokens = tokens.take(pattern.size)

--- a/app/src/main/java/com/github/multimatum_team/multimatum/model/datetime_parser/DateTimeExtractor.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/model/datetime_parser/DateTimeExtractor.kt
@@ -69,14 +69,6 @@ class DateTimeExtractor(private val dateTimePatterns: DateTimePatterns) {
     }
 
     /**
-     * Replaces multiple whitespaces sequences by a single whitespace
-     */
-    private tailrec fun removeMultipleWhitespaces(str: String): String =
-        if (str.contains("  ", ignoreCase = true)) {
-            removeMultipleWhitespaces(str.replace("  ", " ", ignoreCase = true))
-        } else str
-
-    /**
      * Iterates on the list of tokens
      */
     private tailrec fun recursivelyParse(

--- a/app/src/main/java/com/github/multimatum_team/multimatum/model/datetime_parser/DateTimeExtractor.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/model/datetime_parser/DateTimeExtractor.kt
@@ -13,6 +13,21 @@ data class PatternMatchCase(
     val extractionFunc: (List<Any?>) -> ExtractedInfo?
 )
 
+/**
+ * Contains the info extracted by parsing
+ * @param text the text after removing the parts that contain time/date info
+ * @param date the date found in the initial text, if any was found
+ * @param time the time found in the initial text if any was found
+ */
+data class DateTimeExtractionResult(
+    val text: String,
+    val date: LocalDate? = null,
+    val time: LocalTime? = null
+) {
+    val dateFound get() = (date != null)
+    val timeFound get() = (time != null)
+}
+
 class DateTimeExtractor(private val dateTimePatternsGenerator: DateTimePatternsGenerator) {
     constructor(currentDateProvider: () -> LocalDate) :
             this(DateTimePatternsGenerator(currentDateProvider))
@@ -240,19 +255,4 @@ class DateTimeExtractor(private val dateTimePatternsGenerator: DateTimePatternsG
         )
     }
 
-}
-
-/**
- * Contains the info extracted by parsing
- * @param text the text after removing the parts that contain time/date info
- * @param date the date found in the initial text, if any was found
- * @param time the time found in the initial text if any was found
- */
-data class DateTimeExtractionResult(
-    val text: String,
-    val date: LocalDate? = null,
-    val time: LocalTime? = null
-) {
-    val dateFound get() = (date != null)
-    val timeFound get() = (time != null)
 }

--- a/app/src/main/java/com/github/multimatum_team/multimatum/model/datetime_parser/DateTimeExtractor.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/model/datetime_parser/DateTimeExtractor.kt
@@ -82,9 +82,9 @@ class DateTimeExtractor(private val dateTimePatterns: DateTimePatterns) {
         date: LocalDate?,
         time: LocalTime?,
         alreadyProcessedTokensList: MutableList<Token>
-    ): Pair<LocalDate?, LocalTime?> {
+    ): Pair<LocalDate?, LocalTime?> =
         if (remTokens.isEmpty()) {
-            return Pair(date, time)  // end of list, return found info
+            Pair(date, time)  // end of list, return found info
         } else {
             val (extractedInfo, newRemTokens, consumed) = extractDateTimeInfo(remTokens)
             when (extractedInfo) {
@@ -92,21 +92,20 @@ class DateTimeExtractor(private val dateTimePatterns: DateTimePatterns) {
                     // if a date has already been found, ignore the newly found one (treat it as normal text)
                     alreadyProcessedTokensList.addAll(if (date == null) listOf(RemovedToken) else consumed)
                     val newDate = date ?: extractedInfo.date
-                    return recursivelyParse(newRemTokens, newDate, time, alreadyProcessedTokensList)
+                    recursivelyParse(newRemTokens, newDate, time, alreadyProcessedTokensList)
                 }
                 is ExtractedTime -> {
                     // if a time has already been found, ignore the newly found one (treat it as normal text)
                     alreadyProcessedTokensList.addAll(if (time == null) listOf(RemovedToken) else consumed)
                     val newTime = time ?: extractedInfo.time
-                    return recursivelyParse(newRemTokens, date, newTime, alreadyProcessedTokensList)
+                    recursivelyParse(newRemTokens, date, newTime, alreadyProcessedTokensList)
                 }
                 is NoInfo -> {
                     alreadyProcessedTokensList.addAll(consumed)
-                    return recursivelyParse(newRemTokens, date, time, alreadyProcessedTokensList)
+                    recursivelyParse(newRemTokens, date, time, alreadyProcessedTokensList)
                 }
             }
         }
-    }
 
     /**
      * Set followedByWhitespace to true for each token that is followed by a WhitespaceToken

--- a/app/src/main/java/com/github/multimatum_team/multimatum/model/datetime_parser/DateTimePatterns.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/model/datetime_parser/DateTimePatterns.kt
@@ -50,6 +50,7 @@ import java.time.temporal.TemporalAdjusters
  * is applied to the list [15, SymbolToken(":"), 0] and builds an ExtractedTime that contains
  * the time 15:00
  */
+@Suppress("PrivatePropertyName")
 class DateTimePatterns(private val currentDateProvider: () -> LocalDate) {
 
     /**
@@ -83,7 +84,7 @@ class DateTimePatterns(private val currentDateProvider: () -> LocalDate) {
         return ExtractedDate(nextMatchingDay)
     }
 
-    private val simpleTimePat =
+    private val `15h00` =
         listOf(
             Token::asHour,
             Token::asTimeSeparator,
@@ -92,7 +93,7 @@ class DateTimePatterns(private val currentDateProvider: () -> LocalDate) {
             timeFor(hour = args.getInt(0), minute = args.getInt(2))
         }
 
-    private val atTimePat =
+    private val at_15h00 =
         listOf(
             tokenMatchingOneOf("at"),
             Token::asHour,
@@ -102,7 +103,7 @@ class DateTimePatterns(private val currentDateProvider: () -> LocalDate) {
             timeFor(hour = args.getInt(1), minute = args.getInt(3))
         }
 
-    private val amTimePat =
+    private val `3am` =
         listOf(
             Token::asHour,
             tokenMatchingOneOf("am")
@@ -110,7 +111,7 @@ class DateTimePatterns(private val currentDateProvider: () -> LocalDate) {
             timeFor(hour = args.getInt(0), minute = 0)
         }
 
-    private val pmTimePat =
+    private val `3pm` =
         listOf(
             Token::asHour,
             tokenMatchingOneOf("pm")
@@ -118,7 +119,7 @@ class DateTimePatterns(private val currentDateProvider: () -> LocalDate) {
             timeFor(hour = args.getInt(0) + 12, minute = 0)
         }
 
-    private val completeDateDayMonthYearDotsWithSepPat =
+    private val `1-01-2000` =
         listOf(
             Token::asPossibleDayOfMonthIndex,
             Token::asDateSeparator,
@@ -129,7 +130,7 @@ class DateTimePatterns(private val currentDateProvider: () -> LocalDate) {
             dateFor(year = args.getInt(4), month = args.getMonth(2), day = args.getInt(0))
         }
 
-    private val completeDateYearMonthDayWithSepPat =
+    private val `2000-1-1` =
         listOf(
             Token::asPossibleYear,
             Token::asDateSeparator,
@@ -140,7 +141,7 @@ class DateTimePatterns(private val currentDateProvider: () -> LocalDate) {
             dateFor(day = args.getInt(4), month = args.getMonth(2), year = args.getInt(0))
         }
 
-    private val completeDateDayMonthYearNoSepPat =
+    private val `1_01_2000` =
         listOf(
             Token::asPossibleDayOfMonthIndex,
             Token::asMonth,
@@ -149,7 +150,7 @@ class DateTimePatterns(private val currentDateProvider: () -> LocalDate) {
             dateFor(day = args.getInt(0), month = args.getMonth(1), year = args.getInt(2))
         }
 
-    private val dayOfWeekDatePat =
+    private val monday =
         listOf(
             Token::asDayOfWeek
         ) to { args: List<Any?> ->
@@ -157,7 +158,7 @@ class DateTimePatterns(private val currentDateProvider: () -> LocalDate) {
             dateForNextDayMatching(requestedDayOfWeek)
         }
 
-    private val onDayOfWeekDatePat =
+    private val on_monday =
         listOf(
             tokenMatchingOneOf("on", "next"),
             Token::asDayOfWeek
@@ -168,15 +169,15 @@ class DateTimePatterns(private val currentDateProvider: () -> LocalDate) {
 
     val patterns: List<Pair<List<(Token) -> Any?>, (List<Any?>) -> ExtractedInfo?>> =
         listOf(
-            simpleTimePat,
-            atTimePat,
-            amTimePat,
-            pmTimePat,
-            completeDateDayMonthYearDotsWithSepPat,
-            completeDateYearMonthDayWithSepPat,
-            completeDateDayMonthYearNoSepPat,
-            dayOfWeekDatePat,
-            onDayOfWeekDatePat
+            `15h00`,
+            at_15h00,
+            `3am`,
+            `3pm`,
+            `1-01-2000`,
+            `2000-1-1`,
+            `1_01_2000`,
+            monday,
+            on_monday
         )
 
 }

--- a/app/src/main/java/com/github/multimatum_team/multimatum/model/datetime_parser/DateTimePatterns.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/model/datetime_parser/DateTimePatterns.kt
@@ -3,8 +3,6 @@ package com.github.multimatum_team.multimatum.model.datetime_parser
 import java.time.*
 import java.time.temporal.TemporalAdjusters
 
-// TODO update doc
-
 /**
  * Contains all the patterns that the parser should recognize
  *
@@ -14,7 +12,8 @@ import java.time.temporal.TemporalAdjusters
  * considered to match the beginning of the list iff all of these function applications return
  * something else than null. If it matches, the (non-null) results of these function applications
  * are used to build a list that is given as an argument to the second element of the pair, that
- * should use it to build an appropriate ExtractedInfo
+ * should use it to build an appropriate ExtractedInfo. If this ExtractedInfo is null, search for
+ * a matching pattern will resume, until no pattern is left.
  *
  * E.g.: for the pair
  *
@@ -93,6 +92,8 @@ class DateTimePatterns(private val currentDateProvider: () -> LocalDate) {
         val nextMatchingDay = currDate.with(TemporalAdjusters.next(requestedDayOfWeek))
         return ExtractedDate(nextMatchingDay)
     }
+
+    // Patterns
 
     private val `15h` =
         listOf(

--- a/app/src/main/java/com/github/multimatum_team/multimatum/model/datetime_parser/DateTimePatterns.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/model/datetime_parser/DateTimePatterns.kt
@@ -1,0 +1,150 @@
+package com.github.multimatum_team.multimatum.model.datetime_parser
+
+import java.time.LocalDate
+import java.time.LocalTime
+import java.time.YearMonth
+
+/**
+ * Contains all the patterns that the parser should recognize
+ *
+ * Implemented as a list of pairs where the first element is an "extractor", a list of functions
+ * that map a token to any kind of value. This list is applied to the beginning of a list of
+ * tokens by applying the function at index i to the token at index i in the list. A pattern is
+ * considered to match the beginning of the list iff all of these function applications return
+ * something else than null. If it matches, the (non-null) results of these function applications
+ * are used to build a list that is given as an argument to the second element of the pair, that
+ * should use it to build an appropriate ExtractedInfo
+ *
+ * E.g.: for the pair
+ *
+ *    listOf(
+ *       Token::asHour,
+ *       tokenMatching(":"),
+ *       Token::asMinute
+ *    ) to { args: List<Any?> ->
+ *       ExtractedTime(LocalTime.of(args.getInt(0), args.getInt(2)))
+ *    }
+ *
+ * the pattern
+ *
+ *    listOf(
+ *       Token::asHour,
+ *       tokenMatching(":"),
+ *       Token::asMinute
+ *    )
+ *
+ * matches the list
+ *
+ *     listOf(NumericToken("15"), SymbolToken(":"), NumericToken("00"))
+ *
+ * (obtained by tokenizing the string 15:00)
+ *
+ * because asHour returns 15, the function created by tokenMatching(":") returns a non-null
+ * value (the SymbolToken itself) and asMinute returns 0.
+ *
+ * Then the "extractor"
+ *
+ *     args: List<Any?> -> ExtractedTime(LocalTime.of(args.getInt(0), args.getInt(2)))
+ *
+ * is applied to the list [15, SymbolToken(":"), 0] and builds an ExtractedTime that contains
+ * the time 15:00
+ */
+object DateTimePatterns {
+
+    /**
+     * @return a function that takes a token and returns it if it contains the provided string,
+     * null o.w.
+     */
+    private fun tokenMatching(cmpStr: String) =
+        { tok: Token -> if (tok.str == cmpStr) tok else null }
+
+    private fun List<Any?>.getInt(idx: Int): Int = get(idx) as Int
+
+    private val SIMPLE_DATE_PAT =
+        listOf(
+            Token::asHour,
+            tokenMatching(":"),
+            Token::asMinute
+        ) to { args: List<Any?> ->
+            ExtractedTime(LocalTime.of(args.getInt(0), args.getInt(2)))
+        }
+
+    private val AT_TIME_PAT =
+        listOf(
+            tokenMatching("at"),
+            Token::asHour,
+            tokenMatching(":"),
+            Token::asMinute
+        ) to { args: List<Any?> ->
+            ExtractedTime(LocalTime.of(args.getInt(1), args.getInt(3)))
+        }
+
+    private val AM_TIME_PAT =
+        listOf(
+            Token::asHour,
+            tokenMatching("am")
+        ) to { args: List<Any?> ->
+            ExtractedTime(LocalTime.of(args.getInt(0), 0))
+        }
+
+    private val PM_TIME_PAT =
+        listOf(
+            Token::asHour,
+            tokenMatching("pm")
+        ) to { args: List<Any?> ->
+            ExtractedTime(LocalTime.of(args.getInt(0) + 12, 0))
+        }
+
+    private val COMPLETE_DATE_DAY_MONTH_YEAR_PAT =
+        listOf(
+            Token::asPossibleDayOfMonthIndex,
+            tokenMatching("."),
+            Token::asMonthIndex,
+            tokenMatching("."),
+            Token::asPossibleYear
+        ) to { args: List<Any?> ->
+            val dayOfMonth = args.getInt(0)
+            val monthIdx = args.getInt(2)
+            val year = args.getInt(4)
+            val yearMonth = YearMonth.of(year, monthIdx)
+            if (yearMonth.isValidDay(dayOfMonth)) ExtractedDate(
+                LocalDate.of(
+                    year,
+                    monthIdx,
+                    dayOfMonth
+                )
+            ) else null
+        }
+
+    private val COMPLETE_DATE_YEAR_MONTH_DATE =
+        listOf(
+            Token::asPossibleYear,
+            tokenMatching("."),
+            Token::asMonthIndex,
+            tokenMatching("."),
+            Token::asPossibleDayOfMonthIndex
+        ) to { args: List<Any?> ->
+            val dayOfMonth = args.getInt(4)
+            val monthIdx = args.getInt(2)
+            val year = args.getInt(0)
+            val yearMonth = YearMonth.of(year, monthIdx)
+            if (yearMonth.isValidDay(dayOfMonth)) ExtractedDate(
+                LocalDate.of(
+                    year,
+                    monthIdx,
+                    dayOfMonth
+                )
+            ) else null
+        }
+
+    val PATTERNS: List<Pair<List<(Token) -> Any?>, (List<Any?>) -> ExtractedInfo?>> =
+        listOf(
+            SIMPLE_DATE_PAT,
+            AT_TIME_PAT,
+            AM_TIME_PAT,
+            PM_TIME_PAT,
+            COMPLETE_DATE_DAY_MONTH_YEAR_PAT,
+            COMPLETE_DATE_YEAR_MONTH_DATE
+        )
+
+}

--- a/app/src/main/java/com/github/multimatum_team/multimatum/model/datetime_parser/DateTimePatternsGenerator.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/model/datetime_parser/DateTimePatternsGenerator.kt
@@ -50,7 +50,7 @@ import java.time.temporal.TemporalAdjusters
  * the time 15:00
  */
 @Suppress("PrivatePropertyName")
-class DateTimePatterns(private val currentDateProvider: () -> LocalDate) {
+class DateTimePatternsGenerator(private val currentDateProvider: () -> LocalDate) {
 
     /**
      * @return a function that takes a token and returns it if it contains the provided string,
@@ -197,7 +197,7 @@ class DateTimePatterns(private val currentDateProvider: () -> LocalDate) {
             timeFor(0, 0)
         }
 
-    val patterns: List<Pair<List<(Token) -> Any?>, (List<Any?>) -> ExtractedInfo?>> =
+    val patterns: List<PatternMatchCase> =
         listOf(
             `15h`,
             `15h00`,
@@ -210,6 +210,8 @@ class DateTimePatterns(private val currentDateProvider: () -> LocalDate) {
             monday_15,
             midday,
             midnight
-        )
+        ).map { (pattern, extractionFunc) ->
+            PatternMatchCase(pattern, extractionFunc)
+        }
 
 }

--- a/app/src/main/java/com/github/multimatum_team/multimatum/model/datetime_parser/ExtractedInfo.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/model/datetime_parser/ExtractedInfo.kt
@@ -1,0 +1,14 @@
+package com.github.multimatum_team.multimatum.model.datetime_parser
+
+import java.time.LocalDate
+import java.time.LocalTime
+
+/**
+ * Time information extracted from a string
+ * Can be a date, a time or NoInfo if no info was found
+ */
+sealed interface ExtractedInfo
+data class ExtractedDate(val date: LocalDate) : ExtractedInfo
+data class ExtractedTime(val time: LocalTime) : ExtractedInfo
+object NoInfo : ExtractedInfo
+

--- a/app/src/main/java/com/github/multimatum_team/multimatum/model/datetime_parser/Tokens.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/model/datetime_parser/Tokens.kt
@@ -26,7 +26,9 @@ sealed class Token {
      * @return the numeric value of this token if it is numeric and if it is acceptable
      * as an hour (0..23), null o.w.
      */
-    open fun asHour(): Int? = null
+    open fun asHour24(): Int? = null
+
+    open fun asHour12(): Int? = null
 
     /**
      * @return the numeric value of this token if it is numeric and if it is acceptable
@@ -78,7 +80,8 @@ data class NumericToken(override val str: String) : Token() {
     private fun inRangeOrNull(range: IntRange): Int? =
         if (numericValue in range) numericValue else null
 
-    override fun asHour(): Int? = inRangeOrNull(0..23)
+    override fun asHour24(): Int? = inRangeOrNull(0..23)
+    override fun asHour12(): Int? = inRangeOrNull(1..11)
     override fun asMinute(): Int? = inRangeOrNull(0..59)
     override fun asPossibleDayOfMonthIndex(): Int? = inRangeOrNull(1..31)
     override fun asMonth(): Month? = if (numericValue in 1..12) Month.of(numericValue) else null
@@ -109,6 +112,11 @@ object WhitespaceToken : Token() {
     override val str = " "
     override fun toString(): String = "WhitespaceToken"
     override fun filterWhitespace(): Token = this
+}
+
+object RemovedToken : Token(){
+    override val str: String = ""
+    override fun toString(): String = "RemovedToken"
 }
 
 

--- a/app/src/main/java/com/github/multimatum_team/multimatum/model/datetime_parser/Tokens.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/model/datetime_parser/Tokens.kt
@@ -29,6 +29,12 @@ sealed class Token {
      */
     open fun asMinute(): Int? = null
 
+    open fun asPossibleDayOfMonthIndex(): Int? = null
+
+    open fun asMonthIndex(): Int? = null
+
+    open fun asPossibleYear(): Int? = null
+
     fun strWithWhitespaceIfNeeded(): String =
         if (followedByWhitespace) "$str "
         else str
@@ -49,8 +55,15 @@ data class NumericToken(override val str: String) : Token() {
     }
 
     val numericValue: Int get() = str.toInt()
-    override fun asHour(): Int? = if (numericValue in 0..23) numericValue else null
-    override fun asMinute(): Int? = if (numericValue in 0..59) numericValue else null
+
+    private fun inRangeOrNull(range: IntRange): Int? =
+        if (numericValue in range) numericValue else null
+
+    override fun asHour(): Int? = inRangeOrNull(0..23)
+    override fun asMinute(): Int? = inRangeOrNull(0..59)
+    override fun asPossibleDayOfMonthIndex(): Int? = inRangeOrNull(1..31)
+    override fun asMonthIndex(): Int? = inRangeOrNull(1..12)
+    override fun asPossibleYear(): Int? = inRangeOrNull(1900..2999)
 }
 
 /**

--- a/app/src/main/java/com/github/multimatum_team/multimatum/model/datetime_parser/Tokens.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/model/datetime_parser/Tokens.kt
@@ -3,39 +3,47 @@ package com.github.multimatum_team.multimatum.model.datetime_parser
 /**
  * Chunk of text, built of one or several similar characters (e.g. all letters, all digits)
  */
-sealed interface Token {
+sealed class Token {
 
-    val str: String
+    abstract val str: String
+
+    var followedByWhitespace: Boolean = false
 
     // The following methods are default implementations, they are meant to be overridden
     /**
      * @return this if it is a WhitespaceToken, null o.w.
      */
-    fun filterWhitespace(): Token? = null
+    open fun filterWhitespace(): Token? = null
+
+    fun isWhitespace(): Boolean = (filterWhitespace() != null)
 
     /**
      * @return the numeric value of this token if it is numeric and if it is acceptable
      * as an hour (0..23), null o.w.
      */
-    fun asHour(): Int? = null
+    open fun asHour(): Int? = null
 
     /**
      * @return the numeric value of this token if it is numeric and if it is acceptable
      * as a minute (0..59), null o.w.
      */
-    fun asMinute(): Int? = null
+    open fun asMinute(): Int? = null
+
+    fun strWithWhitespaceIfNeeded(): String =
+        if (followedByWhitespace) "$str "
+        else str
 
 }
 
 /**
  * Token containing only letters
  */
-data class AlphabeticToken(override val str: String) : Token
+data class AlphabeticToken(override val str: String) : Token()
 
 /**
  * Token containing only digits
  */
-data class NumericToken(override val str: String) : Token {
+data class NumericToken(override val str: String) : Token() {
     init {
         require(str.all(Char::isDigit))
     }
@@ -48,7 +56,7 @@ data class NumericToken(override val str: String) : Token {
 /**
  * Token containing a (single) symbol
  */
-data class SymbolToken(override val str: String) : Token {
+data class SymbolToken(override val str: String) : Token() {
     init {
         require(str.length == 1)
     }
@@ -59,7 +67,7 @@ data class SymbolToken(override val str: String) : Token {
 /**
  * Token for whitespaces
  */
-object WhitespaceToken : Token {
+object WhitespaceToken : Token() {
     override val str = " "
     override fun toString(): String = "WhitespaceToken"
     override fun filterWhitespace(): Token = this

--- a/app/src/main/java/com/github/multimatum_team/multimatum/model/datetime_parser/Tokens.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/model/datetime_parser/Tokens.kt
@@ -114,6 +114,9 @@ object WhitespaceToken : Token() {
     override fun filterWhitespace(): Token = this
 }
 
+/**
+ * Token indicating that there was initially another token at its place, that was removed
+ */
 object RemovedToken : Token(){
     override val str: String = ""
     override fun toString(): String = "RemovedToken"

--- a/app/src/test/java/com/github/multimatum_team/multimatum/DateTimeExtractorTest.kt
+++ b/app/src/test/java/com/github/multimatum_team/multimatum/DateTimeExtractorTest.kt
@@ -3,7 +3,9 @@ package com.github.multimatum_team.multimatum
 import com.github.multimatum_team.multimatum.model.datetime_parser.DateTimeExtractor
 import org.junit.Assert.*
 import org.junit.Test
+import java.time.LocalDate
 import java.time.LocalTime
+import java.time.Month
 
 class DateTimeExtractorTest {
 
@@ -49,6 +51,63 @@ class DateTimeExtractorTest {
         assertTrue(actualRes.timeFound)
         assertEquals(LocalTime.of(16, 0), actualRes.time)
         assertFalse(actualRes.dateFound)
+    }
+
+    @Test
+    fun complete_date_is_parsed_correctly_in_d_m_y_format(){
+        val str = "Entree en bourse de Multimatum&co 1.08.2022"
+        val expText = "Entree en bourse de Multimatum&co"
+        val actualRes = DateTimeExtractor.parse(str)
+        assertEquals(expText, actualRes.text)
+        assertTrue(actualRes.dateFound)
+        assertEquals(LocalDate.of(2022, Month.AUGUST, 1), actualRes.date)
+        assertFalse(actualRes.timeFound)
+    }
+
+    @Test
+    fun complete_date_is_parsed_correctly_in_y_m_d_format(){
+        val str = "Entree en bourse de Multimatum&co 2022.8.1"
+        val expText = "Entree en bourse de Multimatum&co"
+        val actualRes = DateTimeExtractor.parse(str)
+        assertEquals(expText, actualRes.text)
+        assertTrue(actualRes.dateFound)
+        assertEquals(LocalDate.of(2022, Month.AUGUST, 1), actualRes.date)
+        assertFalse(actualRes.timeFound)
+    }
+
+    @Test
+    fun invalid_date_is_ignored(){
+        // should reject 29.02.2021 (does not exist), but take 5.12.2021 (valid)
+        val str = "New version release 29.2.2021.12.5"
+        val expText = "New version release 29.2."
+        val actualRes = DateTimeExtractor.parse(str)
+        assertEquals(expText, actualRes.text)
+        assertTrue(actualRes.dateFound)
+        assertEquals(LocalDate.of(2021, Month.DECEMBER, 5), actualRes.date)
+        assertFalse(actualRes.timeFound)
+    }
+
+    @Test
+    fun valid_february29_should_be_parsed_correctly(){
+        val str = "Declaration d'impots 29.2.2024"
+        val expText = "Declaration d'impots"
+        val actualRes = DateTimeExtractor.parse(str)
+        assertEquals(expText, actualRes.text)
+        assertTrue(actualRes.dateFound)
+        assertEquals(LocalDate.of(2024, Month.FEBRUARY, 29), actualRes.date)
+        assertFalse(actualRes.timeFound)
+    }
+
+    @Test
+    fun date_and_time_in_same_string_should_be_parsed_correctly(){
+        val str = "Rendu devoir 23.8.2020 14:30"
+        val expStr = "Rendu devoir"
+        val actualRes = DateTimeExtractor.parse(str)
+        assertEquals(expStr, actualRes.text)
+        assertTrue(actualRes.dateFound)
+        assertTrue(actualRes.timeFound)
+        assertEquals(LocalDate.of(2020, 8, 23), actualRes.date)
+        assertEquals(LocalTime.of(14, 30), actualRes.time)
     }
 
 }

--- a/app/src/test/java/com/github/multimatum_team/multimatum/DateTimeExtractorTest.kt
+++ b/app/src/test/java/com/github/multimatum_team/multimatum/DateTimeExtractorTest.kt
@@ -186,4 +186,20 @@ class DateTimeExtractorTest {
         assertFound(expText, expDate = LocalDate.of(2022, Month.JANUARY, 14))(actualRes)
     }
 
+    @Test
+    fun midday_is_parsed_correctly(){
+        val str = "Lunch at noon"
+        val expText = "Lunch"
+        val actualRes = DEFAULT_DATE_TIME_EXTRACTOR.parse(str)
+        assertFound(expText, expTime = LocalTime.NOON)(actualRes)
+    }
+
+    @Test
+    fun midnight_is_parsed_correctly(){
+        val str = "Due work at midnight"
+        val expText = "Due work"
+        val actualRes = DEFAULT_DATE_TIME_EXTRACTOR.parse(str)
+        assertFound(expText, expTime = LocalTime.MIDNIGHT)(actualRes)
+    }
+
 }

--- a/app/src/test/java/com/github/multimatum_team/multimatum/DateTimeExtractorTest.kt
+++ b/app/src/test/java/com/github/multimatum_team/multimatum/DateTimeExtractorTest.kt
@@ -1,5 +1,6 @@
 package com.github.multimatum_team.multimatum
 
+import com.github.multimatum_team.multimatum.model.datetime_parser.DateTimeExtractionResult
 import com.github.multimatum_team.multimatum.model.datetime_parser.DateTimeExtractor
 import org.junit.Assert.*
 import org.junit.Test
@@ -9,105 +10,140 @@ import java.time.Month
 
 class DateTimeExtractorTest {
 
+    companion object {
+        private val DEFAULT_DATE = LocalDate.of(2022, 4, 1)
+        private val DEFAULT_DATE_TIME_PROVIDER = { DEFAULT_DATE }
+        private val DEFAULT_DATE_TIME_EXTRACTOR = DateTimeExtractor(DEFAULT_DATE_TIME_PROVIDER)
+    }
+
+    private fun assertFound(
+        expText: String,
+        expTime: LocalTime? = null,
+        expDate: LocalDate? = null
+    ): (DateTimeExtractionResult) -> Unit = { dateTimeExtractionRes ->
+        assertEquals(expText, dateTimeExtractionRes.text)
+        if (expTime == null) {
+            assertFalse("found time, unexpected", dateTimeExtractionRes.timeFound)
+        } else {
+            assertTrue("expecting time but not found", dateTimeExtractionRes.timeFound)
+            assertEquals(expTime, dateTimeExtractionRes.time)
+        }
+        if (expDate == null) {
+            assertFalse("found date, unexpected", dateTimeExtractionRes.dateFound)
+        } else {
+            assertTrue("expecting date but not found", dateTimeExtractionRes.dateFound)
+            assertEquals(expDate, dateTimeExtractionRes.date)
+        }
+    }
+
     @Test
-    fun time_is_extracted_correctly(){
+    fun time_is_parsed_correctly() {
         val str = "Aqua-pony at 10:00"
         val expText = "Aqua-pony"
-        val actualRes = DateTimeExtractor.parse(str)
-        assertEquals(expText, actualRes.text)
-        assertTrue(actualRes.timeFound)
-        assertEquals(LocalTime.of(10, 0), actualRes.time)
-        assertFalse(actualRes.dateFound)
+        val actualRes = DEFAULT_DATE_TIME_EXTRACTOR.parse(str)
+        assertFound(expText, expTime = LocalTime.of(10, 0))(actualRes)
     }
 
     @Test
-    fun am_time_is_parsed_correctly(){
+    fun am_time_is_parsed_correctly() {
         val str = "Chemistry 2am (report)"
         val expText = "Chemistry (report)"
-        val actualRes = DateTimeExtractor.parse(str)
-        assertEquals(expText, actualRes.text)
-        assertTrue(actualRes.timeFound)
-        assertEquals(LocalTime.of(2, 0), actualRes.time)
-        assertFalse(actualRes.dateFound)
+        val actualRes = DEFAULT_DATE_TIME_EXTRACTOR.parse(str)
+        assertFound(expText, expTime = LocalTime.of(2, 0))(actualRes)
     }
 
     @Test
-    fun pm_time_is_parsed_correctly(){
+    fun pm_time_is_parsed_correctly() {
         val str = "History dissertation 4pm"
         val expText = "History dissertation"
-        val actualRes = DateTimeExtractor.parse(str)
-        assertEquals(expText, actualRes.text)
-        assertTrue(actualRes.timeFound)
-        assertEquals(LocalTime.of(16, 0), actualRes.time)
-        assertFalse(actualRes.dateFound)
+        val actualRes = DEFAULT_DATE_TIME_EXTRACTOR.parse(str)
+        assertFound(expText, expTime = LocalTime.of(16, 0))(actualRes)
     }
 
     @Test
-    fun second_time_is_ignored(){
+    fun second_time_is_ignored() {
         val str = "History dissertation 4pm 5pm"
         val expText = "History dissertation 5pm"
-        val actualRes = DateTimeExtractor.parse(str)
-        assertEquals(expText, actualRes.text)
-        assertTrue(actualRes.timeFound)
-        assertEquals(LocalTime.of(16, 0), actualRes.time)
-        assertFalse(actualRes.dateFound)
+        val actualRes = DEFAULT_DATE_TIME_EXTRACTOR.parse(str)
+        assertFound(expText, expTime = LocalTime.of(16, 0))(actualRes)
     }
 
     @Test
-    fun complete_date_is_parsed_correctly_in_d_m_y_format(){
+    fun complete_date_is_parsed_correctly_in_d_m_y_format() {
         val str = "Entree en bourse de Multimatum&co 1.08.2022"
         val expText = "Entree en bourse de Multimatum&co"
-        val actualRes = DateTimeExtractor.parse(str)
-        assertEquals(expText, actualRes.text)
-        assertTrue(actualRes.dateFound)
-        assertEquals(LocalDate.of(2022, Month.AUGUST, 1), actualRes.date)
-        assertFalse(actualRes.timeFound)
+        val actualRes = DEFAULT_DATE_TIME_EXTRACTOR.parse(str)
+        assertFound(expText, expDate = LocalDate.of(2022, Month.AUGUST, 1))(actualRes)
     }
 
     @Test
-    fun complete_date_is_parsed_correctly_in_y_m_d_format(){
+    fun complete_date_is_parsed_correctly_in_y_m_d_format() {
         val str = "Entree en bourse de Multimatum&co 2022.8.1"
         val expText = "Entree en bourse de Multimatum&co"
-        val actualRes = DateTimeExtractor.parse(str)
-        assertEquals(expText, actualRes.text)
-        assertTrue(actualRes.dateFound)
-        assertEquals(LocalDate.of(2022, Month.AUGUST, 1), actualRes.date)
-        assertFalse(actualRes.timeFound)
+        val actualRes = DEFAULT_DATE_TIME_EXTRACTOR.parse(str)
+        assertFound(expText, expDate = LocalDate.of(2022, Month.AUGUST, 1))(actualRes)
     }
 
     @Test
-    fun invalid_date_is_ignored(){
+    fun invalid_date_is_ignored() {
         // should reject 29.02.2021 (does not exist), but take 5.12.2021 (valid)
         val str = "New version release 29.2.2021.12.5"
         val expText = "New version release 29.2."
-        val actualRes = DateTimeExtractor.parse(str)
-        assertEquals(expText, actualRes.text)
-        assertTrue(actualRes.dateFound)
-        assertEquals(LocalDate.of(2021, Month.DECEMBER, 5), actualRes.date)
-        assertFalse(actualRes.timeFound)
+        val actualRes = DEFAULT_DATE_TIME_EXTRACTOR.parse(str)
+        assertFound(expText, expDate = LocalDate.of(2021, Month.DECEMBER, 5))(actualRes)
     }
 
     @Test
-    fun valid_february29_should_be_parsed_correctly(){
+    fun valid_february29_should_be_parsed_correctly() {
         val str = "Declaration d'impots 29.2.2024"
         val expText = "Declaration d'impots"
-        val actualRes = DateTimeExtractor.parse(str)
-        assertEquals(expText, actualRes.text)
-        assertTrue(actualRes.dateFound)
-        assertEquals(LocalDate.of(2024, Month.FEBRUARY, 29), actualRes.date)
-        assertFalse(actualRes.timeFound)
+        val actualRes = DEFAULT_DATE_TIME_EXTRACTOR.parse(str)
+        assertFound(expText, expDate = LocalDate.of(2024, Month.FEBRUARY, 29))(actualRes)
     }
 
     @Test
-    fun date_and_time_in_same_string_should_be_parsed_correctly(){
+    fun date_and_time_in_same_string_should_be_parsed_correctly() {
         val str = "Rendu devoir 23.8.2020 14:30"
-        val expStr = "Rendu devoir"
-        val actualRes = DateTimeExtractor.parse(str)
-        assertEquals(expStr, actualRes.text)
-        assertTrue(actualRes.dateFound)
-        assertTrue(actualRes.timeFound)
-        assertEquals(LocalDate.of(2020, 8, 23), actualRes.date)
-        assertEquals(LocalTime.of(14, 30), actualRes.time)
+        val expText = "Rendu devoir"
+        val actualRes = DEFAULT_DATE_TIME_EXTRACTOR.parse(str)
+        assertFound(
+            expText,
+            expDate = LocalDate.of(2020, 8, 23),
+            expTime = LocalTime.of(14, 30)
+        )(
+            actualRes
+        )
+    }
+
+    @Test
+    fun day_of_week_should_be_parsed_correctly() {
+        val str = "Meeting SDP friday"
+        val expText = "Meeting SDP"
+        val currentDate = LocalDate.of(2022, Month.APRIL, 30)
+        val nextFriday = LocalDate.of(2022, Month.MAY, 6)
+        val dateTimeExtractor = DateTimeExtractor { currentDate }
+        val actualRes = dateTimeExtractor.parse(str)
+        assertFound(expText, expDate = nextFriday)(actualRes)
+    }
+
+    @Test
+    fun month_given_by_3_letters_name_is_parsed_correctly() {
+        val str = "Devoir a rendre 15 oct 2019"
+        val expStr = "Devoir a rendre"
+        val actualRes = DEFAULT_DATE_TIME_EXTRACTOR.parse(str)
+        assertFound(expStr, expDate = LocalDate.of(2019, Month.OCTOBER, 15))(
+            actualRes
+        )
+    }
+
+    @Test
+    fun month_given_by_full_name_is_parsed_correctly(){
+        val str = "Something to hand-in 23 jan 2018 in math"
+        val expStr = "Something to hand-in in math"
+        val actualRes = DEFAULT_DATE_TIME_EXTRACTOR.parse(str)
+        assertFound(expStr, expDate = LocalDate.of(2018, Month.JANUARY, 23))(
+            actualRes
+        )
     }
 
 }

--- a/app/src/test/java/com/github/multimatum_team/multimatum/DateTimeExtractorTest.kt
+++ b/app/src/test/java/com/github/multimatum_team/multimatum/DateTimeExtractorTest.kt
@@ -117,8 +117,19 @@ class DateTimeExtractorTest {
 
     @Test
     fun day_of_week_should_be_parsed_correctly() {
-        val str = "Meeting SDP friday"
-        val expText = "Meeting SDP"
+        val str = "SDP meeting friday"
+        val expText = "SDP meeting"
+        val currentDate = LocalDate.of(2022, Month.APRIL, 30)
+        val nextFriday = LocalDate.of(2022, Month.MAY, 6)
+        val dateTimeExtractor = DateTimeExtractor { currentDate }
+        val actualRes = dateTimeExtractor.parse(str)
+        assertFound(expText, expDate = nextFriday)(actualRes)
+    }
+
+    @Test
+    fun day_of_week_with_on_should_be_parsed_correctly() {
+        val str = "SDP meeting on friday"
+        val expText = "SDP meeting"
         val currentDate = LocalDate.of(2022, Month.APRIL, 30)
         val nextFriday = LocalDate.of(2022, Month.MAY, 6)
         val dateTimeExtractor = DateTimeExtractor { currentDate }

--- a/app/src/test/java/com/github/multimatum_team/multimatum/DateTimeExtractorTest.kt
+++ b/app/src/test/java/com/github/multimatum_team/multimatum/DateTimeExtractorTest.kt
@@ -37,7 +37,15 @@ class DateTimeExtractorTest {
     }
 
     @Test
-    fun time_is_parsed_correctly() {
+    fun `18h_is_parsed_correctly`(){
+        val str = "Geography 18h"
+        val expText = "Geography"
+        val actualRes = DEFAULT_DATE_TIME_EXTRACTOR.parse(str)
+        assertFound(expText, expTime = LocalTime.of(18, 0))(actualRes)
+    }
+
+    @Test
+    fun `10h00_is_parsed_correctly`() {
         val str = "Aqua-pony at 10:00"
         val expText = "Aqua-pony"
         val actualRes = DEFAULT_DATE_TIME_EXTRACTOR.parse(str)
@@ -140,21 +148,42 @@ class DateTimeExtractorTest {
     @Test
     fun month_given_by_3_letters_name_is_parsed_correctly() {
         val str = "Devoir a rendre 15 oct 2019"
-        val expStr = "Devoir a rendre"
+        val expText = "Devoir a rendre"
         val actualRes = DEFAULT_DATE_TIME_EXTRACTOR.parse(str)
-        assertFound(expStr, expDate = LocalDate.of(2019, Month.OCTOBER, 15))(
+        assertFound(expText, expDate = LocalDate.of(2019, Month.OCTOBER, 15))(
             actualRes
         )
     }
 
     @Test
-    fun month_given_by_full_name_is_parsed_correctly(){
+    fun month_given_by_full_name_is_parsed_correctly() {
         val str = "Something to hand-in 23 jan 2018 in math"
-        val expStr = "Something to hand-in in math"
+        val expText = "Something to hand-in in math"
         val actualRes = DEFAULT_DATE_TIME_EXTRACTOR.parse(str)
-        assertFound(expStr, expDate = LocalDate.of(2018, Month.JANUARY, 23))(
+        assertFound(expText, expDate = LocalDate.of(2018, Month.JANUARY, 23))(
             actualRes
         )
+    }
+
+    @Test
+    fun thursday_20_is_parsed_correctly() {
+        val str = "Physics experiment report thursday 20"
+        val expText = "Physics experiment report"
+        val currentDate = LocalDate.of(2022, Month.JANUARY, 12)
+        val actualRes = DateTimeExtractor { currentDate }.parse(str)
+        assertFound(expText, expDate = LocalDate.of(2022, Month.JANUARY, 20))(actualRes)
+    }
+
+    @Test
+    fun friday_20_is_rejected_when_the_20th_is_not_a_friday() {
+        /* what happens here is that the extractor tries
+         * to match "friday 20", notices that the 20th is not
+         * a friday and falls back to parsing only "friday" */
+        val str = "Physics experiment report friday 20"
+        val expText = "Physics experiment report 20"
+        val currentDate = LocalDate.of(2022, Month.JANUARY, 12)
+        val actualRes = DateTimeExtractor { currentDate }.parse(str)
+        assertFound(expText, expDate = LocalDate.of(2022, Month.JANUARY, 14))(actualRes)
     }
 
 }


### PR DESCRIPTION
The `DateTimeExtractor` is now able to parse both dates and times. The parsing process was slightly modified, among others to account for edge cases like the 29th of february. It has also been linked with the app: when the title of a deadline is added through the "+" button of the main activity, a `DateTimeExtractor` analyzes the title and if it finds a date or time then they are selected (and removed from the title). This part should be refactored next sprint to implement more complex behavior, in particular asking the user in a popup if s-he accepts the auto-completion. <b>Please let me know if you see some missing patterns that you think it should be able to parse </b> (I probably missed some useful ones).

Closes #192
Closes #195 
Closes #193 
Closes #204