### PR TITLE
Adapting darkmode to DeadlineListViewModel

### DIFF
--- a/app/src/main/java/com/github/multimatum_team/multimatum/adaptater/DeadlineAdapter.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/adaptater/DeadlineAdapter.kt
@@ -138,7 +138,6 @@ class DeadlineAdapter(
             }
             clockService.now() > deadline.dateTime -> {
                 detail = context.getString(R.string.isAlreadyDue)
-                detailTextView.setTextColor(Color.BLACK)
                 detailTextView.setTypeface(detailTextView.typeface, Typeface.NORMAL)
             }
             else -> {

--- a/app/src/main/java/com/github/multimatum_team/multimatum/adaptater/DeadlineAdapter.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/adaptater/DeadlineAdapter.kt
@@ -10,6 +10,7 @@ import android.view.ViewGroup
 import android.widget.BaseAdapter
 import android.widget.TextView
 import android.widget.ToggleButton
+import androidx.core.content.ContextCompat
 import com.github.multimatum_team.multimatum.R
 import com.github.multimatum_team.multimatum.model.Deadline
 import com.github.multimatum_team.multimatum.model.DeadlineState
@@ -138,6 +139,12 @@ class DeadlineAdapter(
             }
             clockService.now() > deadline.dateTime -> {
                 detail = context.getString(R.string.isAlreadyDue)
+                detailTextView.setTextColor(
+                    ContextCompat.getColor(
+                        context,
+                        R.color.deadline_details_title
+                    )
+                )
                 detailTextView.setTypeface(detailTextView.typeface, Typeface.NORMAL)
             }
             else -> {

--- a/app/src/main/res/layout/list_item_deadline.xml
+++ b/app/src/main/res/layout/list_item_deadline.xml
@@ -44,7 +44,6 @@
             android:layout_marginTop="2dp"
             android:layout_marginEnd="8dp"
             android:maxLines="1"
-            android:textColor="@color/black"
             android:textSize="12sp"
             tools:ignore="RelativeOverlap"
             tools:text="Detail" />
@@ -58,7 +57,7 @@
             android:focusable="false"
             android:focusableInTouchMode="false"
             android:maxLines="1"
-            android:textColor="#000000"
+            android:textColor="@color/deadline_details_title"
             android:textOff="@string/not_done"
             android:textOn="@string/done"
             android:textSize="12sp" />

--- a/app/src/test/java/com/github/multimatum_team/multimatum/DeadlineAdapterTest.kt
+++ b/app/src/test/java/com/github/multimatum_team/multimatum/DeadlineAdapterTest.kt
@@ -242,10 +242,6 @@ class DeadlineAdapterTest {
             deadlineListDetails
                 .typeface.style
         )
-        Assert.assertEquals(
-            Color.BLACK,
-            deadlineListDetails.currentTextColor
-        )
     }
 
     @Test
@@ -262,10 +258,6 @@ class DeadlineAdapterTest {
             Typeface.NORMAL,
             deadlineListDetails
                 .typeface.style
-        )
-        Assert.assertEquals(
-            Color.BLACK,
-            deadlineListDetails.currentTextColor
         )
         //Set in done
         listItemView.findViewById<ToggleButton>(R.id.deadline_list_check_done).performClick()


### PR DESCRIPTION
This very small PR solves the display problem seen last week where the "due to" text is not displayed correctly in darkmode. The tests have been changed accordingly.