### PR TITLE
Fix stack index constant in `LogUtilImpl`

### DIFF
--- a/app/src/debug/java/com/github/multimatum_team/multimatum/LogUtilImpl.kt
+++ b/app/src/debug/java/com/github/multimatum_team/multimatum/LogUtilImpl.kt
@@ -46,7 +46,7 @@ object LogUtilImpl: LogUtil.FunctionsProvider {
     private const val TAG = "DebugUtil"
 
     // index in the stack to find the environment function
-    private const val STACK_IDX_FOR_ENV_FUNC = 6
+    private const val STACK_IDX_FOR_ENV_FUNC = 7
 
     // counter for the indexing of logging events
     private object Counter {


### PR DESCRIPTION
I updated the logging system last week and forgot to change this constant accordingly, sorry for that!