### PR TITLE
User repository

### DIFF
--- a/app/src/androidTest/java/com/github/multimatum_team/multimatum/CalendarActivityTest.kt
+++ b/app/src/androidTest/java/com/github/multimatum_team/multimatum/CalendarActivityTest.kt
@@ -11,9 +11,11 @@ import com.github.multimatum_team.multimatum.activity.CalendarActivity
 import com.github.multimatum_team.multimatum.repository.AuthRepository
 import com.github.multimatum_team.multimatum.repository.DeadlineRepository
 import com.github.multimatum_team.multimatum.repository.GroupRepository
+import com.github.multimatum_team.multimatum.repository.UserRepository
 import com.github.multimatum_team.multimatum.util.MockAuthRepository
 import com.github.multimatum_team.multimatum.util.MockDeadlineRepository
 import com.github.multimatum_team.multimatum.util.MockGroupRepository
+import com.github.multimatum_team.multimatum.util.MockUserRepository
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -102,5 +104,10 @@ class CalendarActivityTest {
         @Provides
         fun provideAuthRepository(): AuthRepository =
             MockAuthRepository()
+
+        @Singleton
+        @Provides
+        fun provideUserRepository(): UserRepository =
+            MockUserRepository(listOf())
     }
 }

--- a/app/src/androidTest/java/com/github/multimatum_team/multimatum/SignInActivityTest.kt
+++ b/app/src/androidTest/java/com/github/multimatum_team/multimatum/SignInActivityTest.kt
@@ -13,9 +13,11 @@ import com.github.multimatum_team.multimatum.model.DeadlineState
 import com.github.multimatum_team.multimatum.repository.AuthRepository
 import com.github.multimatum_team.multimatum.repository.DeadlineRepository
 import com.github.multimatum_team.multimatum.repository.GroupRepository
+import com.github.multimatum_team.multimatum.repository.UserRepository
 import com.github.multimatum_team.multimatum.util.MockAuthRepository
 import com.github.multimatum_team.multimatum.util.MockDeadlineRepository
 import com.github.multimatum_team.multimatum.util.MockGroupRepository
+import com.github.multimatum_team.multimatum.util.MockUserRepository
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -91,5 +93,10 @@ class SignInActivityTest {
         @Provides
         fun provideAuthRepository(): AuthRepository =
             MockAuthRepository()
+
+        @Singleton
+        @Provides
+        fun provideUserRepository(): UserRepository =
+            MockUserRepository(listOf())
     }
 }

--- a/app/src/androidTest/java/com/github/multimatum_team/multimatum/util/MockAuthRepository.kt
+++ b/app/src/androidTest/java/com/github/multimatum_team/multimatum/util/MockAuthRepository.kt
@@ -27,8 +27,8 @@ class MockAuthRepository : AuthRepository() {
     private fun generateNewAnonymousUser(): AnonymousUser =
         AnonymousUser((uniqueIDSupply++).toString())
 
-    fun signIn(email: String) {
-        _user = SignedInUser(_user.id, email)
+    fun signIn(name: String, email: String) {
+        _user = SignedInUser(_user.id, name, email)
         notifyUpdateListeners()
     }
 

--- a/app/src/androidTest/java/com/github/multimatum_team/multimatum/util/MockUserRepository.kt
+++ b/app/src/androidTest/java/com/github/multimatum_team/multimatum/util/MockUserRepository.kt
@@ -1,0 +1,27 @@
+package com.github.multimatum_team.multimatum.util
+
+import com.github.multimatum_team.multimatum.model.AnonymousUser
+import com.github.multimatum_team.multimatum.model.Deadline
+import com.github.multimatum_team.multimatum.model.UserID
+import com.github.multimatum_team.multimatum.model.UserInfo
+import com.github.multimatum_team.multimatum.repository.DeadlineID
+import com.github.multimatum_team.multimatum.repository.DeadlineRepository
+import com.github.multimatum_team.multimatum.repository.UserRepository
+
+/**
+ * Defines a dummy user info repository that works locally on a plain list.
+ * This way the tests are completely independent from Firebase or network availability.
+ */
+class MockUserRepository(initialContents: List<UserInfo>) : UserRepository() {
+    private val userInfoMap: MutableMap<UserID, UserInfo> =
+        initialContents
+            .associateBy { it.id }
+            .toMutableMap()
+
+    override suspend fun fetch(ids: List<UserID>): List<UserInfo> =
+        ids.map { id -> userInfoMap[id]!! }
+
+    override suspend fun setInfo(userInfo: UserInfo) {
+        userInfoMap[userInfo.id] = userInfo
+    }
+}

--- a/app/src/main/java/com/github/multimatum_team/multimatum/DependenciesProvider.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/DependenciesProvider.kt
@@ -8,6 +8,7 @@ import android.hardware.SensorManager
 import com.github.multimatum_team.multimatum.repository.*
 import com.github.multimatum_team.multimatum.service.ClockService
 import com.github.multimatum_team.multimatum.service.SystemClockService
+import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
 import dagger.Binds
 import dagger.Module
@@ -44,6 +45,11 @@ object ClockModule {
 @Module
 @InstallIn(SingletonComponent::class)
 object FirebaseModule {
+    @Singleton
+    @Provides
+    fun provideFirebaseAuth(): FirebaseAuth =
+        FirebaseAuth.getInstance()
+
     @Singleton
     @Provides
     fun provideFirebaseFirestore(): FirebaseFirestore =

--- a/app/src/main/java/com/github/multimatum_team/multimatum/DependenciesProvider.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/DependenciesProvider.kt
@@ -70,4 +70,8 @@ abstract class FirebaseRepositoryModule {
     @Singleton
     @Binds
     abstract fun provideAuthRepository(impl: FirebaseAuthRepository): AuthRepository
+
+    @Singleton
+    @Binds
+    abstract fun provideUserRepository(impl: FirebaseUserRepository): UserRepository
 }

--- a/app/src/main/java/com/github/multimatum_team/multimatum/ProfileActivity.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/ProfileActivity.kt
@@ -7,10 +7,8 @@ import android.widget.TextView
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import com.firebase.ui.auth.AuthUI
-import com.github.multimatum_team.multimatum.model.AnonymousUser
 import com.github.multimatum_team.multimatum.model.SignedInUser
-import com.github.multimatum_team.multimatum.model.User
-import com.github.multimatum_team.multimatum.viewmodel.UserViewModel
+import com.github.multimatum_team.multimatum.viewmodel.AuthViewModel
 import dagger.hilt.android.AndroidEntryPoint
 import java.lang.IllegalStateException
 
@@ -21,7 +19,7 @@ import java.lang.IllegalStateException
  */
 @AndroidEntryPoint
 class ProfileActivity : AppCompatActivity() {
-    private val userViewModel: UserViewModel by viewModels()
+    private val userViewModel: AuthViewModel by viewModels()
 
     private lateinit var loginMessage: TextView
     private lateinit var logOutButton: Button

--- a/app/src/main/java/com/github/multimatum_team/multimatum/activity/GroupsActivity.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/activity/GroupsActivity.kt
@@ -7,11 +7,16 @@ import androidx.activity.viewModels
 import com.github.multimatum_team.multimatum.LogUtil
 import com.github.multimatum_team.multimatum.R
 import com.github.multimatum_team.multimatum.adaptater.UserGroupAdapter
+import com.github.multimatum_team.multimatum.repository.UserRepository
 import com.github.multimatum_team.multimatum.viewmodel.GroupViewModel
 import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class GroupsActivity : AppCompatActivity() {
+    @Inject
+    lateinit var userRepository: UserRepository
+
     private val groupViewModel: GroupViewModel by viewModels()
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -20,14 +25,11 @@ class GroupsActivity : AppCompatActivity() {
 
         val listView = findViewById<ListView>(R.id.listViewGroups)
 
-        val adapter = UserGroupAdapter(this, groupViewModel)
-
+        val adapter = UserGroupAdapter(this, groupViewModel, userRepository)
 
         listView.adapter = adapter
         groupViewModel.getGroups().observe(this){groups ->
             adapter.setGroups(groups)
         }
-
-        //LogUtil.debugLog()
     }
 }

--- a/app/src/main/java/com/github/multimatum_team/multimatum/activity/MainSettingsActivity.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/activity/MainSettingsActivity.kt
@@ -15,7 +15,7 @@ import com.github.multimatum_team.multimatum.R
 import com.github.multimatum_team.multimatum.model.AnonymousUser
 import com.github.multimatum_team.multimatum.model.SignedInUser
 import com.github.multimatum_team.multimatum.service.ProcrastinationDetectorService
-import com.github.multimatum_team.multimatum.viewmodel.UserViewModel
+import com.github.multimatum_team.multimatum.viewmodel.AuthViewModel
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
@@ -25,7 +25,7 @@ class MainSettingsActivity : AppCompatActivity() {
     private lateinit var notifEnabledButton: SwitchCompat
     private lateinit var procrastinationDetectEnabledButton: SwitchCompat
 
-    private val userViewModel: UserViewModel by viewModels()
+    private val userViewModel: AuthViewModel by viewModels()
 
     @Inject
     lateinit var preferences: SharedPreferences

--- a/app/src/main/java/com/github/multimatum_team/multimatum/adaptater/UserGroupAdapter.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/adaptater/UserGroupAdapter.kt
@@ -8,20 +8,25 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.BaseAdapter
 import android.widget.TextView
+import com.github.multimatum_team.multimatum.LogUtil
 import com.github.multimatum_team.multimatum.R
 import com.github.multimatum_team.multimatum.model.GroupID
 import com.github.multimatum_team.multimatum.model.UserGroup
+import com.github.multimatum_team.multimatum.repository.UserRepository
 import com.github.multimatum_team.multimatum.viewmodel.GroupViewModel
+import kotlinx.coroutines.runBlocking
 
-class UserGroupAdapter(context: Context,
-    private val groupViewModel: GroupViewModel
-): BaseAdapter() {
+class UserGroupAdapter(
+    context: Context,
+    private val groupViewModel: GroupViewModel,
+    private val userRepository: UserRepository
+) : BaseAdapter() {
     private var dataSource: List<UserGroup> = listOf()
     private val inflater: LayoutInflater =
         context.getSystemService(Context.LAYOUT_INFLATER_SERVICE) as LayoutInflater
 
 
-    fun setGroups(groups: Map<GroupID, UserGroup>){
+    fun setGroups(groups: Map<GroupID, UserGroup>) {
         dataSource = groups.values.toList()
         notifyDataSetChanged()
     }
@@ -92,7 +97,8 @@ class UserGroupAdapter(context: Context,
         titleView.setTypeface(null, Typeface.BOLD)
 
         //show the owner
-        subtitleView.text = "own by: " + group.owner
+        val ownerName = runBlocking { userRepository.fetch(group.owner).name }
+        subtitleView.text = "Owner: $ownerName"
         subtitleView.setTypeface(null, Typeface.ITALIC)
 
         return rowView

--- a/app/src/main/java/com/github/multimatum_team/multimatum/model/User.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/model/User.kt
@@ -33,6 +33,6 @@ data class SignedInUser(
     val name: String,
     val email: String
 ) : User {
-    val userInfo: UserInfo
+    val info: UserInfo
       get() = UserInfo(id, name)
 }

--- a/app/src/main/java/com/github/multimatum_team/multimatum/model/User.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/model/User.kt
@@ -3,6 +3,14 @@ package com.github.multimatum_team.multimatum.model
 typealias UserID = String
 
 /**
+ * A class to gather public information about an user.
+ */
+data class UserInfo(
+    val id: UserID,
+    val name: String
+)
+
+/**
  * Model for users.
  */
 sealed interface User {
@@ -22,5 +30,9 @@ data class AnonymousUser(override val id: UserID) : User
  */
 data class SignedInUser(
     override val id: UserID,
+    val name: String,
     val email: String
-) : User
+) : User {
+    val userInfo: UserInfo
+      get() = UserInfo(id, name)
+}

--- a/app/src/main/java/com/github/multimatum_team/multimatum/repository/FirebaseAuthRepository.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/repository/FirebaseAuthRepository.kt
@@ -6,6 +6,7 @@ import com.github.multimatum_team.multimatum.model.SignedInUser
 import com.github.multimatum_team.multimatum.model.User
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.FirebaseUser
+import com.google.firebase.firestore.FirebaseFirestore
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.tasks.await
 import javax.inject.Inject
@@ -14,8 +15,10 @@ import javax.inject.Inject
  * Concrete implementation for the AuthRepository.
  * Acts as a wrapper around the Firebase authentication library.
  */
-class FirebaseAuthRepository @Inject constructor() : AuthRepository() {
-    private val auth: FirebaseAuth = FirebaseAuth.getInstance()
+class FirebaseAuthRepository @Inject constructor(
+    private val auth: FirebaseAuth,
+    private val database: FirebaseFirestore
+) : AuthRepository() {
 
     /**
      * We guarantee that an user is always logged in at any point of the application.

--- a/app/src/main/java/com/github/multimatum_team/multimatum/repository/FirebaseAuthRepository.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/repository/FirebaseAuthRepository.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import com.github.multimatum_team.multimatum.model.AnonymousUser
 import com.github.multimatum_team.multimatum.model.SignedInUser
 import com.github.multimatum_team.multimatum.model.User
+import com.github.multimatum_team.multimatum.model.UserID
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.FirebaseUser
 import com.google.firebase.firestore.FirebaseFirestore
@@ -16,8 +17,7 @@ import javax.inject.Inject
  * Acts as a wrapper around the Firebase authentication library.
  */
 class FirebaseAuthRepository @Inject constructor(
-    private val auth: FirebaseAuth,
-    private val database: FirebaseFirestore
+    private val auth: FirebaseAuth
 ) : AuthRepository() {
 
     /**
@@ -50,7 +50,7 @@ class FirebaseAuthRepository @Inject constructor(
         if (firebaseUser.isAnonymous) {
             AnonymousUser(firebaseUser.uid)
         } else {
-            SignedInUser(firebaseUser.uid, firebaseUser.email!!)
+            SignedInUser(firebaseUser.uid, firebaseUser.displayName!!, firebaseUser.email!!)
         }
 
     /**

--- a/app/src/main/java/com/github/multimatum_team/multimatum/repository/FirebaseUserRepository.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/repository/FirebaseUserRepository.kt
@@ -52,7 +52,6 @@ class FirebaseUserRepository @Inject constructor(database: FirebaseFirestore) : 
             .whereIn(FieldPath.documentId(), ids)
             .get()
             .await()
-            .toList()
             .map { deserializeUserInfo(it) }
 
     /**

--- a/app/src/main/java/com/github/multimatum_team/multimatum/repository/FirebaseUserRepository.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/repository/FirebaseUserRepository.kt
@@ -1,0 +1,66 @@
+package com.github.multimatum_team.multimatum.repository
+
+import com.github.multimatum_team.multimatum.model.UserID
+import com.github.multimatum_team.multimatum.model.UserInfo
+import com.google.firebase.firestore.DocumentSnapshot
+import com.google.firebase.firestore.FieldPath
+import com.google.firebase.firestore.FirebaseFirestore
+import kotlinx.coroutines.tasks.await
+import javax.inject.Inject
+
+/**
+ * An interface to the user repository.
+ * This lets us get publicly available information about signed-in users.
+ */
+class FirebaseUserRepository @Inject constructor(database: FirebaseFirestore) : UserRepository() {
+    private val usersRef = database
+        .collection("users")
+
+    /**
+     * Convert user information into a hashmap, so that we can send the user data to Firebase.
+     */
+    private fun serializeUserInfo(userInfo: UserInfo): HashMap<String, *> =
+        hashMapOf(
+            "name" to userInfo.name,
+        )
+
+    /**
+     * Convert a document snapshot from Firebase to a UserInfo instance.
+     */
+    private fun deserializeUserInfo(userInfoSnapshot: DocumentSnapshot): UserInfo {
+        val id = userInfoSnapshot.id
+        val name = userInfoSnapshot["name"] as String
+        return UserInfo(id, name)
+    }
+
+    /**
+     * Get public information of a user identified by a user ID.
+     */
+    override suspend fun fetch(id: UserID): UserInfo =
+        deserializeUserInfo(
+            usersRef
+                .document(id)
+                .get()
+                .await()
+        )
+
+    /**
+     * Get public information of multiple users at once.
+     */
+    override suspend fun fetch(ids: List<UserID>): List<UserInfo> =
+        usersRef
+            .whereIn(FieldPath.documentId(), ids)
+            .get()
+            .await()
+            .toList()
+            .map { deserializeUserInfo(it) }
+
+    /**
+     * Add information about an signed-in user.
+     */
+    override suspend fun setInfo(userInfo: UserInfo) {
+        usersRef
+            .document(userInfo.id)
+            .set(serializeUserInfo(userInfo))
+    }
+}

--- a/app/src/main/java/com/github/multimatum_team/multimatum/repository/UserRepository.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/repository/UserRepository.kt
@@ -1,0 +1,19 @@
+package com.github.multimatum_team.multimatum.repository
+
+import com.github.multimatum_team.multimatum.model.*
+
+/**
+ * An interface to the user repository.
+ * This lets us get publicly available information about signed-in users.
+ */
+abstract class UserRepository {
+    /**
+     * Get public information of a user identified by a user ID.
+     */
+    abstract suspend fun fetch(id: UserID): UserInfo
+
+    /**
+     * Add information about an signed-in user.
+     */
+    abstract suspend fun add(userInfo: UserInfo)
+}

--- a/app/src/main/java/com/github/multimatum_team/multimatum/repository/UserRepository.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/repository/UserRepository.kt
@@ -10,10 +10,16 @@ abstract class UserRepository {
     /**
      * Get public information of a user identified by a user ID.
      */
-    abstract suspend fun fetch(id: UserID): UserInfo
+    open suspend fun fetch(id: UserID): UserInfo =
+        fetch(listOf(id))[0]
+
+    /**
+     * Get public information of multiple users at once.
+     */
+    abstract suspend fun fetch(ids: List<UserID>): List<UserInfo>
 
     /**
      * Add information about an signed-in user.
      */
-    abstract suspend fun add(userInfo: UserInfo)
+    abstract suspend fun setInfo(userInfo: UserInfo)
 }

--- a/app/src/main/java/com/github/multimatum_team/multimatum/viewmodel/AuthViewModel.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/viewmodel/AuthViewModel.kt
@@ -16,7 +16,7 @@ import kotlinx.coroutines.runBlocking
 import javax.inject.Inject
 
 @HiltViewModel
-class UserViewModel @Inject constructor(
+class AuthViewModel @Inject constructor(
     private val authRepository: AuthRepository
 ) : ViewModel() {
     private val _user: MutableLiveData<User> = MutableLiveData()

--- a/app/src/main/java/com/github/multimatum_team/multimatum/viewmodel/AuthViewModel.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/viewmodel/AuthViewModel.kt
@@ -1,6 +1,5 @@
 package com.github.multimatum_team.multimatum.viewmodel
 
-import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -9,15 +8,15 @@ import com.github.multimatum_team.multimatum.LogUtil
 import com.github.multimatum_team.multimatum.model.SignedInUser
 import com.github.multimatum_team.multimatum.model.User
 import com.github.multimatum_team.multimatum.repository.AuthRepository
-import com.github.multimatum_team.multimatum.repository.GroupRepository
+import com.github.multimatum_team.multimatum.repository.UserRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import javax.inject.Inject
 
 @HiltViewModel
 class AuthViewModel @Inject constructor(
-    private val authRepository: AuthRepository
+    private val authRepository: AuthRepository,
+    userRepository: UserRepository
 ) : ViewModel() {
     private val _user: MutableLiveData<User> = MutableLiveData()
 
@@ -29,6 +28,9 @@ class AuthViewModel @Inject constructor(
 
         authRepository.onUpdate { newUser ->
             LogUtil.debugLog("update auth: $newUser")
+            if (newUser is SignedInUser) {
+                viewModelScope.launch { userRepository.setInfo(newUser.info) }
+            }
             _user.value = newUser
         }
     }

--- a/app/src/test/java/com/github/multimatum_team/multimatum/AddDeadlineTest.kt
+++ b/app/src/test/java/com/github/multimatum_team/multimatum/AddDeadlineTest.kt
@@ -11,18 +11,17 @@ import androidx.test.espresso.UiController
 import androidx.test.espresso.ViewAction
 import androidx.test.espresso.action.ViewActions
 import androidx.test.espresso.intent.Intents
-import androidx.test.espresso.matcher.ViewMatchers.*
+import androidx.test.espresso.matcher.ViewMatchers.isAssignableFrom
+import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.multimatum_team.multimatum.activity.AddDeadlineActivity
 import com.github.multimatum_team.multimatum.repository.AuthRepository
 import com.github.multimatum_team.multimatum.repository.DeadlineRepository
 import com.github.multimatum_team.multimatum.repository.GroupRepository
+import com.github.multimatum_team.multimatum.repository.UserRepository
 import com.github.multimatum_team.multimatum.service.ClockService
-import com.github.multimatum_team.multimatum.util.MockAuthRepository
-import com.github.multimatum_team.multimatum.util.MockClockService
-import com.github.multimatum_team.multimatum.util.MockDeadlineRepository
-import com.github.multimatum_team.multimatum.util.MockGroupRepository
+import com.github.multimatum_team.multimatum.util.*
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -200,6 +199,11 @@ class AddDeadlineTest {
         @Provides
         fun provideAuthRepository(): AuthRepository =
             MockAuthRepository()
+
+        @Singleton
+        @Provides
+        fun provideUserRepository(): UserRepository =
+            MockUserRepository(listOf())
     }
 
     @Module

--- a/app/src/test/java/com/github/multimatum_team/multimatum/AuthViewModelTest.kt
+++ b/app/src/test/java/com/github/multimatum_team/multimatum/AuthViewModelTest.kt
@@ -68,7 +68,7 @@ class AuthViewModelTest {
 
     @Test
     fun `LiveData is updated when the user signs in`() {
-        (authRepository as MockAuthRepository).signIn("john.doe@example.com")
+        (authRepository as MockAuthRepository).signIn("John Doe", "john.doe@example.com")
         assertEquals(viewModel.getUser().value!!, SignedInUser("0","John Doe", "john.doe@example.com"))
     }
 

--- a/app/src/test/java/com/github/multimatum_team/multimatum/AuthViewModelTest.kt
+++ b/app/src/test/java/com/github/multimatum_team/multimatum/AuthViewModelTest.kt
@@ -7,9 +7,11 @@ import com.github.multimatum_team.multimatum.model.SignedInUser
 import com.github.multimatum_team.multimatum.repository.AuthRepository
 import com.github.multimatum_team.multimatum.repository.DeadlineRepository
 import com.github.multimatum_team.multimatum.repository.GroupRepository
+import com.github.multimatum_team.multimatum.repository.UserRepository
 import com.github.multimatum_team.multimatum.util.MockAuthRepository
 import com.github.multimatum_team.multimatum.util.MockDeadlineRepository
 import com.github.multimatum_team.multimatum.util.MockGroupRepository
+import com.github.multimatum_team.multimatum.util.MockUserRepository
 import com.github.multimatum_team.multimatum.viewmodel.AuthViewModel
 import dagger.Module
 import dagger.Provides
@@ -35,9 +37,12 @@ import javax.inject.Singleton
 @HiltAndroidTest
 @UninstallModules(FirebaseRepositoryModule::class)
 @ExperimentalCoroutinesApi
-class UserViewModelTest {
+class AuthViewModelTest {
     @Inject
     lateinit var authRepository: AuthRepository
+
+    @Inject
+    lateinit var userRepository: UserRepository
 
     private lateinit var viewModel: AuthViewModel
 
@@ -53,7 +58,7 @@ class UserViewModelTest {
     fun setUp() {
         Dispatchers.setMain(UnconfinedTestDispatcher())
         hiltRule.inject()
-        viewModel = AuthViewModel(authRepository)
+        viewModel = AuthViewModel(authRepository, userRepository)
     }
 
     @Test
@@ -64,7 +69,7 @@ class UserViewModelTest {
     @Test
     fun `LiveData is updated when the user signs in`() {
         (authRepository as MockAuthRepository).signIn("john.doe@example.com")
-        assertEquals(viewModel.getUser().value!!, SignedInUser("0", "john.doe@example.com"))
+        assertEquals(viewModel.getUser().value!!, SignedInUser("0","John Doe", "john.doe@example.com"))
     }
 
     @Test
@@ -90,5 +95,10 @@ class UserViewModelTest {
         @Provides
         fun provideAuthRepository(): AuthRepository =
             MockAuthRepository()
+
+        @Singleton
+        @Provides
+        fun provideUserRepository(): UserRepository =
+            MockUserRepository(listOf())
     }
 }

--- a/app/src/test/java/com/github/multimatum_team/multimatum/DateTimeExtractorTest.kt
+++ b/app/src/test/java/com/github/multimatum_team/multimatum/DateTimeExtractorTest.kt
@@ -37,7 +37,7 @@ class DateTimeExtractorTest {
     }
 
     @Test
-    fun `18h_is_parsed_correctly`(){
+    fun `18h_is_parsed_correctly`() {
         val str = "Geography 18h"
         val expText = "Geography"
         val actualRes = DEFAULT_DATE_TIME_EXTRACTOR.parse(str)
@@ -187,7 +187,7 @@ class DateTimeExtractorTest {
     }
 
     @Test
-    fun midday_is_parsed_correctly(){
+    fun midday_is_parsed_correctly() {
         val str = "Lunch at noon"
         val expText = "Lunch"
         val actualRes = DEFAULT_DATE_TIME_EXTRACTOR.parse(str)
@@ -195,7 +195,7 @@ class DateTimeExtractorTest {
     }
 
     @Test
-    fun midnight_is_parsed_correctly(){
+    fun midnight_is_parsed_correctly() {
         val str = "Due work at midnight"
         val expText = "Due work"
         val actualRes = DEFAULT_DATE_TIME_EXTRACTOR.parse(str)

--- a/app/src/test/java/com/github/multimatum_team/multimatum/DeadlineAdapterTest.kt
+++ b/app/src/test/java/com/github/multimatum_team/multimatum/DeadlineAdapterTest.kt
@@ -14,15 +14,9 @@ import com.github.multimatum_team.multimatum.adaptater.DeadlineAdapter
 import com.github.multimatum_team.multimatum.model.AnonymousUser
 import com.github.multimatum_team.multimatum.model.Deadline
 import com.github.multimatum_team.multimatum.model.DeadlineState
-import com.github.multimatum_team.multimatum.repository.AuthRepository
-import com.github.multimatum_team.multimatum.repository.DeadlineID
-import com.github.multimatum_team.multimatum.repository.DeadlineRepository
-import com.github.multimatum_team.multimatum.repository.GroupRepository
+import com.github.multimatum_team.multimatum.repository.*
 import com.github.multimatum_team.multimatum.service.ClockService
-import com.github.multimatum_team.multimatum.util.MockAuthRepository
-import com.github.multimatum_team.multimatum.util.MockClockService
-import com.github.multimatum_team.multimatum.util.MockDeadlineRepository
-import com.github.multimatum_team.multimatum.util.MockGroupRepository
+import com.github.multimatum_team.multimatum.util.*
 import com.github.multimatum_team.multimatum.viewmodel.DeadlineListViewModel
 import dagger.Module
 import dagger.Provides
@@ -318,5 +312,10 @@ class DeadlineAdapterTest {
         @Provides
         fun provideAuthRepository(): AuthRepository =
             MockAuthRepository()
+
+        @Singleton
+        @Provides
+        fun provideUserRepository(): UserRepository =
+            MockUserRepository(listOf())
     }
 }

--- a/app/src/test/java/com/github/multimatum_team/multimatum/DeadlineDetailsTest.kt
+++ b/app/src/test/java/com/github/multimatum_team/multimatum/DeadlineDetailsTest.kt
@@ -12,7 +12,8 @@ import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.intent.Intents
 import androidx.test.espresso.intent.matcher.IntentMatchers.*
-import androidx.test.espresso.matcher.ViewMatchers.*
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.multimatum_team.multimatum.activity.DeadlineDetailsActivity
 import com.github.multimatum_team.multimatum.activity.QRGeneratorActivity
@@ -21,11 +22,9 @@ import com.github.multimatum_team.multimatum.model.DeadlineState
 import com.github.multimatum_team.multimatum.repository.AuthRepository
 import com.github.multimatum_team.multimatum.repository.DeadlineRepository
 import com.github.multimatum_team.multimatum.repository.GroupRepository
+import com.github.multimatum_team.multimatum.repository.UserRepository
 import com.github.multimatum_team.multimatum.service.ClockService
-import com.github.multimatum_team.multimatum.util.MockAuthRepository
-import com.github.multimatum_team.multimatum.util.MockClockService
-import com.github.multimatum_team.multimatum.util.MockDeadlineRepository
-import com.github.multimatum_team.multimatum.util.MockGroupRepository
+import com.github.multimatum_team.multimatum.util.*
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -304,5 +303,10 @@ class DeadlineDetailsTest {
         @Provides
         fun provideAuthRepository(): AuthRepository =
             MockAuthRepository()
+
+        @Singleton
+        @Provides
+        fun provideUserRepository(): UserRepository =
+            MockUserRepository(listOf())
     }
 }

--- a/app/src/test/java/com/github/multimatum_team/multimatum/DeadlineListViewModelTest.kt
+++ b/app/src/test/java/com/github/multimatum_team/multimatum/DeadlineListViewModelTest.kt
@@ -2,7 +2,6 @@ package com.github.multimatum_team.multimatum
 
 import android.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.test.core.app.ApplicationProvider
-import androidx.test.espresso.intent.Intents
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.multimatum_team.multimatum.model.AnonymousUser
 import com.github.multimatum_team.multimatum.model.Deadline
@@ -11,10 +10,8 @@ import com.github.multimatum_team.multimatum.model.UserID
 import com.github.multimatum_team.multimatum.repository.AuthRepository
 import com.github.multimatum_team.multimatum.repository.DeadlineRepository
 import com.github.multimatum_team.multimatum.repository.GroupRepository
-import com.github.multimatum_team.multimatum.util.MockAuthRepository
-import com.github.multimatum_team.multimatum.util.MockDeadlineRepository
-import com.github.multimatum_team.multimatum.util.MockGroupRepository
-import com.github.multimatum_team.multimatum.util.getOrAwaitValue
+import com.github.multimatum_team.multimatum.repository.UserRepository
+import com.github.multimatum_team.multimatum.util.*
 import com.github.multimatum_team.multimatum.viewmodel.DeadlineListViewModel
 import dagger.Module
 import dagger.Provides
@@ -28,7 +25,6 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
-import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Rule
@@ -214,5 +210,10 @@ class DeadlineListViewModelTest {
         @Provides
         fun provideAuthRepository(): AuthRepository =
             MockAuthRepository()
+
+        @Singleton
+        @Provides
+        fun provideUserRepository(): UserRepository =
+            MockUserRepository(listOf())
     }
 }

--- a/app/src/test/java/com/github/multimatum_team/multimatum/DeadlineRepositoryTest.kt
+++ b/app/src/test/java/com/github/multimatum_team/multimatum/DeadlineRepositoryTest.kt
@@ -3,20 +3,10 @@ package com.github.multimatum_team.multimatum
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.multimatum_team.multimatum.model.Deadline
 import com.github.multimatum_team.multimatum.model.DeadlineState
-import com.github.multimatum_team.multimatum.model.UserGroup
-import com.github.multimatum_team.multimatum.repository.AuthRepository
 import com.github.multimatum_team.multimatum.repository.DeadlineRepository
-import com.github.multimatum_team.multimatum.repository.GroupRepository
-import com.github.multimatum_team.multimatum.util.MockAuthRepository
 import com.github.multimatum_team.multimatum.util.MockDeadlineRepository
-import com.github.multimatum_team.multimatum.util.MockGroupRepository
-import dagger.Module
-import dagger.Provides
-import dagger.hilt.InstallIn
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
-import dagger.hilt.android.testing.UninstallModules
-import dagger.hilt.components.SingletonComponent
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
@@ -25,8 +15,6 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.time.LocalDateTime
-import javax.inject.Inject
-import javax.inject.Singleton
 
 @RunWith(AndroidJUnit4::class)
 @ExperimentalCoroutinesApi

--- a/app/src/test/java/com/github/multimatum_team/multimatum/DeadlineTest.kt
+++ b/app/src/test/java/com/github/multimatum_team/multimatum/DeadlineTest.kt
@@ -5,7 +5,6 @@ import com.github.multimatum_team.multimatum.model.DeadlineState
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertThrows
 import org.junit.Test
-import java.time.Duration
 import java.time.LocalDateTime
 import java.time.Month
 

--- a/app/src/test/java/com/github/multimatum_team/multimatum/FirebaseDeadlineRepositoryTest.kt
+++ b/app/src/test/java/com/github/multimatum_team/multimatum/FirebaseDeadlineRepositoryTest.kt
@@ -3,10 +3,8 @@ package com.github.multimatum_team.multimatum
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.multimatum_team.multimatum.model.*
 import com.github.multimatum_team.multimatum.repository.FirebaseDeadlineRepository
-import com.github.multimatum_team.multimatum.util.DeadlineData
-import com.github.multimatum_team.multimatum.util.GroupOwnedData
-import com.github.multimatum_team.multimatum.util.MockFirebaseFirestore
-import com.github.multimatum_team.multimatum.util.UserOwnedData
+import com.github.multimatum_team.multimatum.util.*
+import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
 import dagger.Module
 import dagger.Provides
@@ -202,7 +200,7 @@ class FirebaseDeadlineRepositoryTest {
         @Provides
         fun provideFirebaseFirestore(): FirebaseFirestore =
             MockFirebaseFirestore(
-                listOf(
+                deadlines = listOf(
                     DeadlineData(
                         "Deadline 1",
                         DeadlineState.DONE,
@@ -225,11 +223,21 @@ class FirebaseDeadlineRepositoryTest {
                         GroupOwnedData("0")
                     )
                 ),
-                listOf(
+                groups = listOf(
                     UserGroup("0", "Group 1", "0", setOf("0", "1", "2")),
                     UserGroup("1", "Group 2", "1", setOf("0", "1")),
                     UserGroup("2", "Group 3", "0", setOf("0", "2")),
+                ),
+                users = listOf(
+                    UserInfo("0", "Pierre"),
+                    UserInfo("1", "Paul"),
+                    UserInfo("2", "Jacques"),
                 )
             ).database
+
+        @Singleton
+        @Provides
+        fun provideFirebaseAuth(): FirebaseAuth =
+            MockFirebaseAuth().auth
     }
 }

--- a/app/src/test/java/com/github/multimatum_team/multimatum/FirebaseDeadlineRepositoryTest.kt
+++ b/app/src/test/java/com/github/multimatum_team/multimatum/FirebaseDeadlineRepositoryTest.kt
@@ -45,11 +45,13 @@ class FirebaseDeadlineRepositoryTest {
         hiltRule.inject()
         repository = FirebaseDeadlineRepository(database)
         repository.setUser(AnonymousUser("0"))
-        repository.setGroups(mapOf(
-            "0" to UserGroup("0", "Group 1", "0", setOf("0", "1", "2")),
-            "1" to UserGroup("1", "Group 2", "1", setOf("0", "1")),
-            "2" to UserGroup("2", "Group 3", "0", setOf("0", "2")),
-        ))
+        repository.setGroups(
+            mapOf(
+                "0" to UserGroup("0", "Group 1", "0", setOf("0", "1", "2")),
+                "1" to UserGroup("1", "Group 2", "1", setOf("0", "1")),
+                "2" to UserGroup("2", "Group 3", "0", setOf("0", "2")),
+            )
+        )
     }
 
     @Test
@@ -123,13 +125,15 @@ class FirebaseDeadlineRepositoryTest {
 
     @Test
     fun `Creating a deadline inserts a new deadline owned by the current user`() = runTest {
-        repository.put(Deadline(
-            "Deadline 4",
-            DeadlineState.TODO,
-            LocalDateTime.of(2022, 5, 15, 0, 0),
-            "Deadline 4 description",
-            UserOwned
-        ))
+        repository.put(
+            Deadline(
+                "Deadline 4",
+                DeadlineState.TODO,
+                LocalDateTime.of(2022, 5, 15, 0, 0),
+                "Deadline 4 description",
+                UserOwned
+            )
+        )
         assertEquals(
             mapOf(
                 "1" to Deadline(
@@ -179,13 +183,15 @@ class FirebaseDeadlineRepositoryTest {
     fun `Creating a deadline notifies the owner`() = runTest {
         var notified = false
         repository.onUpdate { notified = true }
-        repository.put(Deadline(
-            "Deadline 4",
-            DeadlineState.TODO,
-            LocalDateTime.of(2022, 5, 15, 0, 0),
-            "Deadline 4 description",
-            UserOwned
-        ))
+        repository.put(
+            Deadline(
+                "Deadline 4",
+                DeadlineState.TODO,
+                LocalDateTime.of(2022, 5, 15, 0, 0),
+                "Deadline 4 description",
+                UserOwned
+            )
+        )
         assertTrue(notified)
     }
 

--- a/app/src/test/java/com/github/multimatum_team/multimatum/FirebaseGroupRepositoryTest.kt
+++ b/app/src/test/java/com/github/multimatum_team/multimatum/FirebaseGroupRepositoryTest.kt
@@ -3,7 +3,9 @@ package com.github.multimatum_team.multimatum
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.multimatum_team.multimatum.model.UserGroup
 import com.github.multimatum_team.multimatum.repository.FirebaseGroupRepository
+import com.github.multimatum_team.multimatum.util.MockFirebaseAuth
 import com.github.multimatum_team.multimatum.util.MockFirebaseFirestore
+import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
 import dagger.Module
 import dagger.Provides
@@ -111,12 +113,18 @@ class FirebaseGroupRepositoryTest {
         @Provides
         fun provideFirebaseFirestore(): FirebaseFirestore =
             MockFirebaseFirestore(
-                listOf(),
-                listOf(
+                deadlines = listOf(),
+                groups = listOf(
                     UserGroup("0", "Group 1", "0", setOf("0", "1", "2")),
                     UserGroup("1", "Group 2", "1", setOf("0", "1")),
                     UserGroup("2", "Group 3", "0", setOf("0", "2")),
-                )
+                ),
+                users = listOf()
             ).database
+
+        @Singleton
+        @Provides
+        fun provideFirebaseAuth(): FirebaseAuth =
+            MockFirebaseAuth().auth
     }
 }

--- a/app/src/test/java/com/github/multimatum_team/multimatum/FirebaseGroupRepositoryTest.kt
+++ b/app/src/test/java/com/github/multimatum_team/multimatum/FirebaseGroupRepositoryTest.kt
@@ -1,7 +1,6 @@
 package com.github.multimatum_team.multimatum
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.github.multimatum_team.multimatum.model.AnonymousUser
 import com.github.multimatum_team.multimatum.model.UserGroup
 import com.github.multimatum_team.multimatum.repository.FirebaseGroupRepository
 import com.github.multimatum_team.multimatum.util.MockFirebaseFirestore

--- a/app/src/test/java/com/github/multimatum_team/multimatum/FirebaseUserRepositoryTest.kt
+++ b/app/src/test/java/com/github/multimatum_team/multimatum/FirebaseUserRepositoryTest.kt
@@ -1,0 +1,110 @@
+package com.github.multimatum_team.multimatum
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.multimatum_team.multimatum.model.UserGroup
+import com.github.multimatum_team.multimatum.model.UserInfo
+import com.github.multimatum_team.multimatum.repository.FirebaseGroupRepository
+import com.github.multimatum_team.multimatum.repository.FirebaseUserRepository
+import com.github.multimatum_team.multimatum.util.MockFirebaseAuth
+import com.github.multimatum_team.multimatum.util.MockFirebaseFirestore
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.firestore.FirebaseFirestore
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import dagger.hilt.android.testing.UninstallModules
+import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@RunWith(AndroidJUnit4::class)
+@ExperimentalCoroutinesApi
+@HiltAndroidTest
+@UninstallModules(FirebaseModule::class)
+class FirebaseUserRepositoryTest {
+    @Inject
+    lateinit var database: FirebaseFirestore
+
+    lateinit var repository: FirebaseUserRepository
+
+    @get:Rule
+    var hiltRule = HiltAndroidRule(this)
+
+    @Before
+    fun setup() {
+        hiltRule.inject()
+        repository = FirebaseUserRepository(database)
+    }
+
+    @Test
+    fun `Fetching user info works`() = runTest {
+        assertEquals(
+            UserInfo("1", "Léo"),
+            repository.fetch("1")
+        )
+    }
+
+    @Test
+    fun `Fetching multiple user info at once works`() = runTest {
+        assertEquals(
+            listOf(
+                UserInfo("0", "Valentin"),
+                UserInfo("3", "Lenny"),
+            ),
+            repository.fetch(listOf("0", "3"))
+        )
+    }
+
+    @Test
+    fun `Setting info for a new user updates the repository correctly`() = runTest {
+        repository.setInfo(UserInfo("6", "Yugesh"))
+        assertEquals(
+            repository.fetch("6"),
+            UserInfo("6", "Yugesh")
+        )
+    }
+
+    @Test
+    fun `Setting info for an existing user updates the user correctly`() = runTest {
+        repository.setInfo(UserInfo("4", "Louise"))
+        assertEquals(
+            repository.fetch("4"),
+            UserInfo("4", "Louise")
+        )
+    }
+
+    @Module
+    @InstallIn(SingletonComponent::class)
+    object TestFirebaseModule {
+        @Singleton
+        @Provides
+        fun provideFirebaseFirestore(): FirebaseFirestore =
+            MockFirebaseFirestore(
+                deadlines = listOf(),
+                groups = listOf(),
+                users = listOf(
+                    UserInfo("0", "Valentin"),
+                    UserInfo("1", "Léo"),
+                    UserInfo("2", "Florian"),
+                    UserInfo("3", "Lenny"),
+                    UserInfo("4", "Louis"),
+                    UserInfo("5", "Joseph"),
+                )
+            ).database
+
+        @Singleton
+        @Provides
+        fun provideFirebaseAuth(): FirebaseAuth =
+            MockFirebaseAuth().auth
+    }
+}

--- a/app/src/test/java/com/github/multimatum_team/multimatum/GroupAdapterTest.kt
+++ b/app/src/test/java/com/github/multimatum_team/multimatum/GroupAdapterTest.kt
@@ -9,10 +9,7 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.intent.Intents
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.multimatum_team.multimatum.adaptater.UserGroupAdapter
-import com.github.multimatum_team.multimatum.model.AnonymousUser
-import com.github.multimatum_team.multimatum.model.GroupID
-import com.github.multimatum_team.multimatum.model.SignedInUser
-import com.github.multimatum_team.multimatum.model.UserGroup
+import com.github.multimatum_team.multimatum.model.*
 import com.github.multimatum_team.multimatum.repository.AuthRepository
 import com.github.multimatum_team.multimatum.repository.DeadlineRepository
 import com.github.multimatum_team.multimatum.repository.GroupRepository
@@ -40,13 +37,11 @@ import javax.inject.Singleton
 class GroupAdapterTest {
     companion object {
         private val groups: List<UserGroup> = listOf(
-            UserGroup("1", "SDP", "Joseph", setOf("Joseph", "Louis", "Florian", "Léo", "Val")),
-            UserGroup("2", "MIT", "Louis", setOf("Joseph", "Louis", "Florian", "Léo", "Val")),
-            UserGroup("3", "JDR", "Florian", setOf("Joseph", "Louis", "Florian", "Léo", "Val")),
-            UserGroup("4", "Quantic", "Léo", setOf("Joseph", "Louis", "Florian", "Léo", "Val")),
-            UserGroup("4", "Quantic", "Léo", setOf("Joseph", "Louis", "Florian", "Léo")),
-
-            )
+            UserGroup("0", "SDP", "Joseph", setOf("Joseph", "Louis", "Florian", "Léo", "Val")),
+            UserGroup("1", "MIT", "Louis", setOf("Joseph", "Louis", "Florian", "Léo", "Val")),
+            UserGroup("2", "JDR", "Florian", setOf("Joseph", "Louis", "Florian", "Léo", "Val")),
+            UserGroup("3", "Quantic", "Léo", setOf("Joseph", "Louis", "Florian", "Léo", "Val")),
+        )
     }
 
     @get:Rule
@@ -137,7 +132,7 @@ class GroupAdapterTest {
         )
         //check subtitle
         Assert.assertEquals(
-            "own by: Louis",
+            "Owner: Louis",
             listItemView.findViewById<TextView>(R.id.group_list_owner).text
         )
         Assert.assertEquals(
@@ -167,6 +162,12 @@ class GroupAdapterTest {
         @Singleton
         @Provides
         fun provideUserRepository(): UserRepository =
-            MockUserRepository(listOf())
+            MockUserRepository(listOf(
+                UserInfo(id = "Joseph", name = "Joseph"),
+                UserInfo(id = "Louis", name = "Louis"),
+                UserInfo(id = "Florian", name = "Florian"),
+                UserInfo(id = "Léo", name = "Léo"),
+                UserInfo(id = "Val", name = "Val"),
+            ))
     }
 }

--- a/app/src/test/java/com/github/multimatum_team/multimatum/GroupAdapterTest.kt
+++ b/app/src/test/java/com/github/multimatum_team/multimatum/GroupAdapterTest.kt
@@ -1,7 +1,6 @@
 package com.github.multimatum_team.multimatum
 
 import android.app.Application
-import android.graphics.Color
 import android.graphics.Typeface
 import android.view.View
 import android.widget.ListView
@@ -17,9 +16,11 @@ import com.github.multimatum_team.multimatum.model.UserGroup
 import com.github.multimatum_team.multimatum.repository.AuthRepository
 import com.github.multimatum_team.multimatum.repository.DeadlineRepository
 import com.github.multimatum_team.multimatum.repository.GroupRepository
+import com.github.multimatum_team.multimatum.repository.UserRepository
 import com.github.multimatum_team.multimatum.util.MockAuthRepository
 import com.github.multimatum_team.multimatum.util.MockDeadlineRepository
 import com.github.multimatum_team.multimatum.util.MockGroupRepository
+import com.github.multimatum_team.multimatum.util.MockUserRepository
 import com.github.multimatum_team.multimatum.viewmodel.GroupViewModel
 import dagger.Module
 import dagger.Provides
@@ -30,10 +31,8 @@ import dagger.hilt.android.testing.UninstallModules
 import dagger.hilt.components.SingletonComponent
 import org.junit.*
 import org.junit.runner.RunWith
-import java.lang.Exception
 import javax.inject.Inject
 import javax.inject.Singleton
-import kotlin.jvm.Throws
 
 @RunWith(AndroidJUnit4::class)
 @HiltAndroidTest
@@ -59,6 +58,9 @@ class GroupAdapterTest {
     @Inject
     lateinit var authRepository: AuthRepository
 
+    @Inject
+    lateinit var userRepository: UserRepository
+
     private lateinit var adapter: UserGroupAdapter
     private var context: Application? = null
     private lateinit var groupMap: Map<GroupID, UserGroup>
@@ -75,7 +77,7 @@ class GroupAdapterTest {
             groupRepository
         )
 
-        adapter = UserGroupAdapter(context!!, viewModel)
+        adapter = UserGroupAdapter(context!!, viewModel, userRepository)
         groupMap = groups.associateBy { it.id }
         adapter.setGroups(groupMap)
     }
@@ -86,8 +88,14 @@ class GroupAdapterTest {
     }
 
     @Test
-    fun `Get count should give correct count`(){
-        (authRepository as MockAuthRepository).logIn(SignedInUser("Val", "val.dormeur@décédé.fr"))
+    fun `Get count should give correct count`() {
+        (authRepository as MockAuthRepository).logIn(
+            SignedInUser(
+                "Val",
+                "Val Dormeur",
+                "val.dormeur@décédé.fr"
+            )
+        )
         Assert.assertEquals(4, adapter.count)
     }
 
@@ -100,7 +108,7 @@ class GroupAdapterTest {
     }
 
     @Test
-    fun `GetItemId should give the correct id`(){
+    fun `GetItemId should give the correct id`() {
         Assert.assertEquals(adapter.getItemId(0), 0.toLong())
         Assert.assertEquals(adapter.getItemId(1), 1.toLong())
         Assert.assertEquals(adapter.getItemId(2), 2.toLong())
@@ -108,8 +116,14 @@ class GroupAdapterTest {
     }
 
     @Test
-    fun `GetView should display all field with correct font`(){
-        (authRepository as MockAuthRepository).logIn(SignedInUser("Val", "val.dormeur@décédé.fr"))
+    fun `GetView should display all field with correct font`() {
+        (authRepository as MockAuthRepository).logIn(
+            SignedInUser(
+                "Val",
+                "Val Dormeur",
+                "val.dormeur@décédé.fr"
+            )
+        )
         val parent = ListView(context)
         val listItemView: View = adapter.getView(1, null, parent)
         //check title
@@ -149,5 +163,10 @@ class GroupAdapterTest {
         @Provides
         fun provideAuthRepository(): AuthRepository =
             MockAuthRepository()
+
+        @Singleton
+        @Provides
+        fun provideUserRepository(): UserRepository =
+            MockUserRepository(listOf())
     }
 }

--- a/app/src/test/java/com/github/multimatum_team/multimatum/GroupViewModelTest.kt
+++ b/app/src/test/java/com/github/multimatum_team/multimatum/GroupViewModelTest.kt
@@ -1,17 +1,14 @@
 package com.github.multimatum_team.multimatum
 
 import android.arch.core.executor.testing.InstantTaskExecutorRule
-import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.multimatum_team.multimatum.model.AnonymousUser
 import com.github.multimatum_team.multimatum.model.UserGroup
 import com.github.multimatum_team.multimatum.repository.AuthRepository
 import com.github.multimatum_team.multimatum.repository.DeadlineRepository
 import com.github.multimatum_team.multimatum.repository.GroupRepository
-import com.github.multimatum_team.multimatum.util.MockAuthRepository
-import com.github.multimatum_team.multimatum.util.MockDeadlineRepository
-import com.github.multimatum_team.multimatum.util.MockGroupRepository
-import com.github.multimatum_team.multimatum.util.getOrAwaitValue
+import com.github.multimatum_team.multimatum.repository.UserRepository
+import com.github.multimatum_team.multimatum.util.*
 import com.github.multimatum_team.multimatum.viewmodel.GroupViewModel
 import dagger.Module
 import dagger.Provides
@@ -176,5 +173,10 @@ class GroupViewModelTest {
         @Provides
         fun provideAuthRepository(): AuthRepository =
             MockAuthRepository()
+
+        @Singleton
+        @Provides
+        fun provideUserRepository(): UserRepository =
+            MockUserRepository(listOf())
     }
 }

--- a/app/src/test/java/com/github/multimatum_team/multimatum/MainActivityTest.kt
+++ b/app/src/test/java/com/github/multimatum_team/multimatum/MainActivityTest.kt
@@ -25,9 +25,11 @@ import com.github.multimatum_team.multimatum.model.UserGroup
 import com.github.multimatum_team.multimatum.repository.AuthRepository
 import com.github.multimatum_team.multimatum.repository.DeadlineRepository
 import com.github.multimatum_team.multimatum.repository.GroupRepository
+import com.github.multimatum_team.multimatum.repository.UserRepository
 import com.github.multimatum_team.multimatum.util.MockAuthRepository
 import com.github.multimatum_team.multimatum.util.MockDeadlineRepository
 import com.github.multimatum_team.multimatum.util.MockGroupRepository
+import com.github.multimatum_team.multimatum.util.MockUserRepository
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -138,7 +140,7 @@ class MainActivityTest {
     }
 
     @Test
-    fun goToGroupsTest(){
+    fun goToGroupsTest() {
         onView(withId(R.id.groupButton)).perform(click())
         Intents.intended(
             allOf(
@@ -240,16 +242,23 @@ class MainActivityTest {
         @Singleton
         @Provides
         fun provideGroupRepository(): GroupRepository =
-            MockGroupRepository(listOf(
-                UserGroup("1", "SDP", "joseph"),
-                UserGroup("2", "JDR", "Florian"),
-                UserGroup("3", "Camera", "Leo")
-            ))
+            MockGroupRepository(
+                listOf(
+                    UserGroup("1", "SDP", "joseph"),
+                    UserGroup("2", "JDR", "Florian"),
+                    UserGroup("3", "Camera", "Leo")
+                )
+            )
 
         @Singleton
         @Provides
         fun provideAuthRepository(): AuthRepository =
             MockAuthRepository()
+
+        @Singleton
+        @Provides
+        fun provideUserRepository(): UserRepository =
+            MockUserRepository(listOf())
     }
 
     companion object {

--- a/app/src/test/java/com/github/multimatum_team/multimatum/MainSettingsActivityTest.kt
+++ b/app/src/test/java/com/github/multimatum_team/multimatum/MainSettingsActivityTest.kt
@@ -91,7 +91,7 @@ class MainSettingsActivityTest {
 
     @Test
     fun launchProfileActivityIntent() = runTest {
-        (authRepository as MockAuthRepository).signIn("john.doe@example.com")
+        (authRepository as MockAuthRepository).signIn("John Doe", "john.doe@example.com")
         val scenario = ActivityScenario.launch(MainSettingsActivity::class.java)
         scenario.use {
             onView(withId(R.id.main_settings_account_button)).perform(click())

--- a/app/src/test/java/com/github/multimatum_team/multimatum/MainSettingsActivityTest.kt
+++ b/app/src/test/java/com/github/multimatum_team/multimatum/MainSettingsActivityTest.kt
@@ -21,9 +21,11 @@ import com.github.multimatum_team.multimatum.model.DeadlineState
 import com.github.multimatum_team.multimatum.repository.AuthRepository
 import com.github.multimatum_team.multimatum.repository.DeadlineRepository
 import com.github.multimatum_team.multimatum.repository.GroupRepository
+import com.github.multimatum_team.multimatum.repository.UserRepository
 import com.github.multimatum_team.multimatum.util.MockAuthRepository
 import com.github.multimatum_team.multimatum.util.MockDeadlineRepository
 import com.github.multimatum_team.multimatum.util.MockGroupRepository
+import com.github.multimatum_team.multimatum.util.MockUserRepository
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -206,6 +208,11 @@ class MainSettingsActivityTest {
         @Provides
         fun provideAuthRepository(): AuthRepository =
             MockAuthRepository()
+
+        @Singleton
+        @Provides
+        fun provideUserRepository(): UserRepository =
+            MockUserRepository(listOf())
     }
 
     companion object {

--- a/app/src/test/java/com/github/multimatum_team/multimatum/PDFUtilTest.kt
+++ b/app/src/test/java/com/github/multimatum_team/multimatum/PDFUtilTest.kt
@@ -9,9 +9,8 @@ import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 class PDFUtilTest {
-
     @Test
-    fun testSelectPDF (){
+    fun testSelectPDF() {
         PDFUtil.selectPdfIntent {
             assertEquals(Intent.ACTION_GET_CONTENT, it.action)
         }

--- a/app/src/test/java/com/github/multimatum_team/multimatum/QRGeneratorActivityTest.kt
+++ b/app/src/test/java/com/github/multimatum_team/multimatum/QRGeneratorActivityTest.kt
@@ -65,15 +65,18 @@ class QRGeneratorActivityTest {
 
     @Test
     fun qRDisplayTest() {
-        val data = Deadline("Appeller Robert", DeadlineState.TODO, LocalDateTime.now()
-            .plusDays(1))
+        val data = Deadline(
+            "Appeller Robert", DeadlineState.TODO, LocalDateTime.now()
+                .plusDays(1)
+        )
         val intent = Intent(
             ApplicationProvider.getApplicationContext(),
             QRGeneratorActivity::class.java
         ).putExtra(EXTRA_TEXT, Gson().toJson(data))
         val scenario = ActivityScenario.launch<QRGeneratorActivity>(intent)
         scenario.use {
-            Espresso.onView(ViewMatchers.withId(R.id.QRGenerated)).check(matches(withQRCode(Gson().toJson(data))))
+            Espresso.onView(ViewMatchers.withId(R.id.QRGenerated))
+                .check(matches(withQRCode(Gson().toJson(data))))
         }
     }
 

--- a/app/src/test/java/com/github/multimatum_team/multimatum/ReminderBroadcastReceiverTest.kt
+++ b/app/src/test/java/com/github/multimatum_team/multimatum/ReminderBroadcastReceiverTest.kt
@@ -34,7 +34,6 @@ import org.robolectric.shadows.ShadowNotificationManager
 @RunWith(AndroidJUnit4::class)
 @HiltAndroidTest
 class ReminderBroadcastReceiverTest {
-
     private lateinit var context: Context
 
     @get:Rule
@@ -82,11 +81,11 @@ class ReminderBroadcastReceiverTest {
         fun provideSharedPreferences(): SharedPreferences = mockSharedPreferences
 
         @Provides
-        fun provideSensorManager(@ApplicationContext context: Context): SensorManager = DependenciesProvider.provideSensorManager(context)
+        fun provideSensorManager(@ApplicationContext context: Context): SensorManager =
+            DependenciesProvider.provideSensorManager(context)
     }
 
     companion object {
         private val mockSharedPreferences: SharedPreferences = mock()
     }
-
 }

--- a/app/src/test/java/com/github/multimatum_team/multimatum/TokensTest.kt
+++ b/app/src/test/java/com/github/multimatum_team/multimatum/TokensTest.kt
@@ -1,15 +1,13 @@
 package com.github.multimatum_team.multimatum
 
 import com.github.multimatum_team.multimatum.model.datetime_parser.*
-import org.junit.Test
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertThrows
-import java.lang.IllegalArgumentException
+import org.junit.Test
 
 class TokensTest {
-
     @Test
-    fun string_is_tokenized_correctly(){
+    fun string_is_tokenized_correctly() {
         val str = "abcd1234 !/xyz. 987"
         val exp = listOf(
             AlphabeticToken("abcd"),
@@ -26,7 +24,7 @@ class TokensTest {
     }
 
     @Test
-    fun deadline_title_including_date_and_time_is_tokenized_correctly(){
+    fun deadline_title_including_date_and_time_is_tokenized_correctly() {
         val title = "Aqua-poney monday 15 at 11am"
         val exp = listOf(
             AlphabeticToken("Aqua"),
@@ -46,40 +44,40 @@ class TokensTest {
     }
 
     @Test
-    fun numericToken_gives_correct_numeric_value(){
+    fun numericToken_gives_correct_numeric_value() {
         val inputsOutputs = listOf(
             "123" to 123,
             "0" to 0,
             "47" to 47
         )
-        for ((input, output) in inputsOutputs){
+        for ((input, output) in inputsOutputs) {
             assertEquals(output, NumericToken(input).numericValue)
         }
     }
 
-    @Test fun symbolToken_gives_correct_char_value(){
+    @Test
+    fun symbolToken_gives_correct_char_value() {
         val inputsOutputs = listOf(
             "!" to '!',
             "*" to '*',
             "@" to '@'
         )
-        for ((input, output) in inputsOutputs){
+        for ((input, output) in inputsOutputs) {
             assertEquals(output, SymbolToken(input).charValue)
         }
     }
 
     @Test
-    fun numericToken_throws_on_non_numeric_input(){
-        assertThrows(IllegalArgumentException::class.java){
+    fun numericToken_throws_on_non_numeric_input() {
+        assertThrows(IllegalArgumentException::class.java) {
             NumericToken("123a4")
         }
     }
 
     @Test
-    fun symbolToken_throws_on_input_with_length_different_of_1(){
-        assertThrows(IllegalArgumentException::class.java){
+    fun symbolToken_throws_on_input_with_length_different_of_1() {
+        assertThrows(IllegalArgumentException::class.java) {
             SymbolToken("[!]")
         }
     }
-
 }

--- a/app/src/test/java/com/github/multimatum_team/multimatum/UserRepositoryTest.kt
+++ b/app/src/test/java/com/github/multimatum_team/multimatum/UserRepositoryTest.kt
@@ -1,0 +1,55 @@
+package com.github.multimatum_team.multimatum
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.multimatum_team.multimatum.model.Deadline
+import com.github.multimatum_team.multimatum.model.DeadlineState
+import com.github.multimatum_team.multimatum.model.UserInfo
+import com.github.multimatum_team.multimatum.repository.DeadlineRepository
+import com.github.multimatum_team.multimatum.repository.UserRepository
+import com.github.multimatum_team.multimatum.util.MockDeadlineRepository
+import com.github.multimatum_team.multimatum.util.MockUserRepository
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.time.LocalDateTime
+
+@RunWith(AndroidJUnit4::class)
+@ExperimentalCoroutinesApi
+@HiltAndroidTest
+class UserRepositoryTest {
+    private val repository: UserRepository = MockUserRepository(
+        listOf(
+            UserInfo("0", "Valentin"),
+            UserInfo("1", "Léo"),
+            UserInfo("2", "Florian"),
+            UserInfo("3", "Lenny"),
+            UserInfo("4", "Louis"),
+            UserInfo("5", "Joseph"),
+        )
+    )
+
+    @get:Rule
+    var hiltRule = HiltAndroidRule(this)
+
+    @Test
+    fun `Default implementation of fetch returns the right deadline`() = runTest {
+        assertEquals(
+            UserInfo("0", "Valentin"),
+            repository.fetch("0")
+        )
+        assertEquals(
+            UserInfo("1", "Léo"),
+            repository.fetch("1")
+        )
+        assertEquals(
+            UserInfo("2", "Florian"),
+            repository.fetch("2")
+        )
+    }
+}

--- a/app/src/test/java/com/github/multimatum_team/multimatum/UserViewModelTest.kt
+++ b/app/src/test/java/com/github/multimatum_team/multimatum/UserViewModelTest.kt
@@ -10,7 +10,7 @@ import com.github.multimatum_team.multimatum.repository.GroupRepository
 import com.github.multimatum_team.multimatum.util.MockAuthRepository
 import com.github.multimatum_team.multimatum.util.MockDeadlineRepository
 import com.github.multimatum_team.multimatum.util.MockGroupRepository
-import com.github.multimatum_team.multimatum.viewmodel.UserViewModel
+import com.github.multimatum_team.multimatum.viewmodel.AuthViewModel
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -39,7 +39,7 @@ class UserViewModelTest {
     @Inject
     lateinit var authRepository: AuthRepository
 
-    private lateinit var viewModel: UserViewModel
+    private lateinit var viewModel: AuthViewModel
 
     // Set executor to be synchronous so that LiveData's notify their observers immediately and
     // finish executing before continuing.
@@ -53,7 +53,7 @@ class UserViewModelTest {
     fun setUp() {
         Dispatchers.setMain(UnconfinedTestDispatcher())
         hiltRule.inject()
-        viewModel = UserViewModel(authRepository)
+        viewModel = AuthViewModel(authRepository)
     }
 
     @Test

--- a/app/src/test/java/com/github/multimatum_team/multimatum/util/MockAuthRepository.kt
+++ b/app/src/test/java/com/github/multimatum_team/multimatum/util/MockAuthRepository.kt
@@ -27,8 +27,8 @@ class MockAuthRepository : AuthRepository() {
     private fun generateNewAnonymousUser(): AnonymousUser =
         AnonymousUser((uniqueIDSupply++).toString())
 
-    fun signIn(email: String) {
-        _user = SignedInUser(_user.id, email)
+    fun signIn(name: String, email: String) {
+        _user = SignedInUser(_user.id, name, email)
         notifyUpdateListeners()
     }
 

--- a/app/src/test/java/com/github/multimatum_team/multimatum/util/MockFirebaseAuth.kt
+++ b/app/src/test/java/com/github/multimatum_team/multimatum/util/MockFirebaseAuth.kt
@@ -1,0 +1,8 @@
+package com.github.multimatum_team.multimatum.util
+
+import com.google.firebase.auth.FirebaseAuth
+import org.mockito.Mockito
+
+class MockFirebaseAuth {
+    val auth: FirebaseAuth = Mockito.mock(FirebaseAuth::class.java)
+}

--- a/app/src/test/java/com/github/multimatum_team/multimatum/util/MockUserRepository.kt
+++ b/app/src/test/java/com/github/multimatum_team/multimatum/util/MockUserRepository.kt
@@ -1,0 +1,27 @@
+package com.github.multimatum_team.multimatum.util
+
+import com.github.multimatum_team.multimatum.model.AnonymousUser
+import com.github.multimatum_team.multimatum.model.Deadline
+import com.github.multimatum_team.multimatum.model.UserID
+import com.github.multimatum_team.multimatum.model.UserInfo
+import com.github.multimatum_team.multimatum.repository.DeadlineID
+import com.github.multimatum_team.multimatum.repository.DeadlineRepository
+import com.github.multimatum_team.multimatum.repository.UserRepository
+
+/**
+ * Defines a dummy user info repository that works locally on a plain list.
+ * This way the tests are completely independent from Firebase or network availability.
+ */
+class MockUserRepository(initialContents: List<UserInfo>) : UserRepository() {
+    private val userInfoMap: MutableMap<UserID, UserInfo> =
+        initialContents
+            .associateBy { it.id }
+            .toMutableMap()
+
+    override suspend fun fetch(ids: List<UserID>): List<UserInfo> =
+        ids.map { id -> userInfoMap[id]!! }
+
+    override suspend fun setInfo(userInfo: UserInfo) {
+        userInfoMap[userInfo.id] = userInfo
+    }
+}

--- a/reports/sprint9.md
+++ b/reports/sprint9.md
@@ -59,3 +59,5 @@ created and add a slider to modifiy the sensitivity of the procrastination
 detector.
 
 ### Overall team
+
+This week everyone works on news feature, a lots of refractoring was done.  All this feature have a solid basis to work on it efficiently next week. But a lots of task seems to take more time than expecte so we didn't plan all our task for next week. We have to do this by the end of the sprint.


### PR DESCRIPTION
This PR implements the user repository as described in #233.
Thanks to this new repository, public user information is now stored in firebase firestore, which lets us see user names from user IDs, which wouldn't have been possible otherwise.
The reason for this repository is to show the name of the group owner and members in the `GroupsActivity` and the upcoming `GroupDetailsActivity` (see #234).

Closes #233.