### PR TITLE
Feature/procrastination detector sensibility slider

### DIFF
--- a/app/src/main/java/com/github/multimatum_team/multimatum/activity/MainSettingsActivity.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/activity/MainSettingsActivity.kt
@@ -44,9 +44,9 @@ class MainSettingsActivity : AppCompatActivity() {
         setContentView(R.layout.activity_main_settings)
         assignWidgets()
         loadButtonsState()
+        initializeProcrastinationDetectorSensitivitySlider()
         setWidgetListeners()
         disableProcrastinationFighterButtonIfSensorNotFound()
-        initializeProcrastinationDetectorSensitivitySlider()
     }
 
     private fun initializeProcrastinationDetectorSensitivitySlider() {
@@ -99,14 +99,8 @@ class MainSettingsActivity : AppCompatActivity() {
             // slider can be moved iff procrastination detector is enabled
             procrastinationDetectorSlider.isEnabled = newState
         }
-        setOnSeekBarChangeListener()
-    }
-
-    private fun setOnSeekBarChangeListener() {
-        procrastinationDetectorSlider.addOnChangeListener(Slider.OnChangeListener { _, value, fromUser ->
-            if (fromUser) { // write only if from user, not when slider created
-                writeNewSensitivityValue(value.toInt())
-            }
+        procrastinationDetectorSlider.addOnChangeListener(Slider.OnChangeListener { _, value, _ ->
+            writeNewSensitivityValue(value.toInt())
         })
     }
 

--- a/app/src/main/java/com/github/multimatum_team/multimatum/activity/MainSettingsActivity.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/activity/MainSettingsActivity.kt
@@ -6,10 +6,13 @@ import android.hardware.SensorManager
 import android.os.Bundle
 import android.util.Log
 import android.view.View
+import android.widget.LinearLayout
+import android.widget.SeekBar
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.appcompat.widget.SwitchCompat
+import com.github.multimatum_team.multimatum.LogUtil
 import com.github.multimatum_team.multimatum.ProfileActivity
 import com.github.multimatum_team.multimatum.R
 import com.github.multimatum_team.multimatum.model.AnonymousUser
@@ -24,6 +27,8 @@ class MainSettingsActivity : AppCompatActivity() {
     private lateinit var darkModeEnabledButton: SwitchCompat
     private lateinit var notifEnabledButton: SwitchCompat
     private lateinit var procrastinationDetectEnabledButton: SwitchCompat
+    private lateinit var procrastinationDetectorSlider: SeekBar
+    private lateinit var procrastinationDetectorSliderBar: LinearLayout
 
     private val userViewModel: UserViewModel by viewModels()
 
@@ -41,6 +46,18 @@ class MainSettingsActivity : AppCompatActivity() {
         loadButtonsState()
         setWidgetListeners()
         disableProcrastinationFighterButtonIfSensorNotFound()
+        initializeProcrastinationDetectorSensitivitySlider()
+    }
+
+    private fun initializeProcrastinationDetectorSensitivitySlider() {
+        // slider can be moved iff procrastination fighter is enabled
+        procrastinationDetectorSlider.isEnabled = procrastinationDetectEnabledButton.isChecked
+        procrastinationDetectorSlider.max = ProcrastinationDetectorService.MAX_SENSITIVITY
+        // progress stands for position on the bar
+        procrastinationDetectorSlider.incrementProgressBy(preferences.getInt(
+            PROCRASTINATION_FIGHTER_SENSITIVITY_PREF_KEY,
+            ProcrastinationDetectorService.DEFAULT_SENSITIVITY
+        ))
     }
 
     /*
@@ -53,7 +70,7 @@ class MainSettingsActivity : AppCompatActivity() {
         val sensorPresent = sensorFound()
         // if no sensor available then button should be gray to show that it is disabled
         procrastinationDetectEnabledButton.alpha =
-            if (sensorPresent) BUTTON_ALPHA_NORMAL else BUTTON_ALPHA_DISABLED
+            if (sensorPresent) ALPHA_NORMAL else ALPHA_DISABLED
         if (!sensorPresent) {
             procrastinationDetectEnabledButton.text = applicationContext.getString(
                 R.string.missing_sensor_msg, procrastinationDetectEnabledButton.text
@@ -69,14 +86,41 @@ class MainSettingsActivity : AppCompatActivity() {
                 true -> AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_YES)
                 false -> AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_NO)
             }
-            writeNewState(DARK_MODE_PREF_KEY, newState)
+            writeNewBooleanState(DARK_MODE_PREF_KEY, newState)
         }
         notifEnabledButton.setOnCheckedChangeListener { _, newState ->
-            writeNewState(NOTIF_ENABLED_PREF_KEY, newState)
+            writeNewBooleanState(NOTIF_ENABLED_PREF_KEY, newState)
         }
         procrastinationDetectEnabledButton.setOnCheckedChangeListener { _, newState ->
-            writeNewState(PROCRASTINATION_FIGHTER_ENABLED_PREF_KEY, newState)
+            writeNewBooleanState(PROCRASTINATION_FIGHTER_ENABLED_PREF_KEY, newState)
+            // slider can be moved iff procrastination detector is enabled
+            procrastinationDetectorSlider.isEnabled = newState
         }
+        setOnSeekBarChangeListener()
+    }
+
+    private fun setOnSeekBarChangeListener() {
+        procrastinationDetectorSlider.setOnSeekBarChangeListener(
+            object : SeekBar.OnSeekBarChangeListener {
+                override fun onProgressChanged(
+                    seekBar: SeekBar?,
+                    progress: Int,
+                    fromUser: Boolean
+                ) {
+                    if (fromUser){ // write only if from user, not when slider created
+                        writeNewSensitivityValue(progress)
+                    }
+                }
+
+                override fun onStartTrackingTouch(seekBar: SeekBar?) {
+                    /* do nothing */
+                }
+
+                override fun onStopTrackingTouch(seekBar: SeekBar?) {
+                    /* do nothing */
+                }
+            }
+        )
     }
 
     // sets the buttons to the state they had last time the app was stopped
@@ -94,12 +138,24 @@ class MainSettingsActivity : AppCompatActivity() {
         notifEnabledButton = findViewById(R.id.main_settings_enable_notif_button)
         procrastinationDetectEnabledButton =
             findViewById(R.id.main_settings_enable_procrastination_fighter_button)
+        procrastinationDetectorSlider =
+            findViewById(R.id.main_settings_procrastination_detector_sensibility_slider)
+        procrastinationDetectorSliderBar =
+            findViewById(R.id.main_settings_procrastination_detector_sensibility_bar)
     }
 
     // writes the key/state pair to SharedPreferences
-    private fun writeNewState(key: String, currState: Boolean) {
+    private fun writeNewBooleanState(key: String, currState: Boolean) {
         val edit = preferences.edit()
         edit.putBoolean(key, currState)
+        edit.apply()
+    }
+
+    // write sensitivity to SharedPreferences
+    private fun writeNewSensitivityValue(sensitivityValue: Int) {
+        LogUtil.logFunctionCall("new sensitivity value: $sensitivityValue")
+        val edit = preferences.edit()
+        edit.putInt(PROCRASTINATION_FIGHTER_SENSITIVITY_PREF_KEY, sensitivityValue)
         edit.apply()
     }
 
@@ -109,8 +165,8 @@ class MainSettingsActivity : AppCompatActivity() {
 
     companion object {
         private const val TAG = "MainSettingsActivity"
-        private const val BUTTON_ALPHA_NORMAL = 1F
-        private const val BUTTON_ALPHA_DISABLED = 0.5F
+        private const val ALPHA_NORMAL = 1F
+        private const val ALPHA_DISABLED = 0.5F
 
         /**
          * Key for the storage of whether dark mode is enabled in SharedPreferences
@@ -130,6 +186,11 @@ class MainSettingsActivity : AppCompatActivity() {
         const val PROCRASTINATION_FIGHTER_ENABLED_PREF_KEY =
             "com.github.multimatum_team.multimatum.activity.MainSettingsActivity.ProcrastinationFighterEnabled"
 
+        /**
+         * Key for the storage of the sensitivity of the procrastination detector
+         */
+        const val PROCRASTINATION_FIGHTER_SENSITIVITY_PREF_KEY =
+            "com.github.multimatum_team.multimatum.activity.MainSettingsActivity.ProcrastinationFighterSensitivity"
     }
 
     fun goToAccountSettings(view: View) {

--- a/app/src/main/java/com/github/multimatum_team/multimatum/activity/MainSettingsActivity.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/activity/MainSettingsActivity.kt
@@ -7,7 +7,6 @@ import android.os.Bundle
 import android.util.Log
 import android.view.View
 import android.widget.LinearLayout
-import android.widget.SeekBar
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.app.AppCompatDelegate
@@ -19,6 +18,7 @@ import com.github.multimatum_team.multimatum.model.AnonymousUser
 import com.github.multimatum_team.multimatum.model.SignedInUser
 import com.github.multimatum_team.multimatum.service.ProcrastinationDetectorService
 import com.github.multimatum_team.multimatum.viewmodel.UserViewModel
+import com.google.android.material.slider.Slider
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
@@ -27,7 +27,7 @@ class MainSettingsActivity : AppCompatActivity() {
     private lateinit var darkModeEnabledButton: SwitchCompat
     private lateinit var notifEnabledButton: SwitchCompat
     private lateinit var procrastinationDetectEnabledButton: SwitchCompat
-    private lateinit var procrastinationDetectorSlider: SeekBar
+    private lateinit var procrastinationDetectorSlider: Slider
     private lateinit var procrastinationDetectorSliderBar: LinearLayout
 
     private val userViewModel: UserViewModel by viewModels()
@@ -52,12 +52,15 @@ class MainSettingsActivity : AppCompatActivity() {
     private fun initializeProcrastinationDetectorSensitivitySlider() {
         // slider can be moved iff procrastination fighter is enabled
         procrastinationDetectorSlider.isEnabled = procrastinationDetectEnabledButton.isChecked
-        procrastinationDetectorSlider.max = ProcrastinationDetectorService.MAX_SENSITIVITY
+        procrastinationDetectorSlider.valueFrom = 0f
+        procrastinationDetectorSlider.valueTo =
+            ProcrastinationDetectorService.MAX_SENSITIVITY.toFloat()
+        procrastinationDetectorSlider.stepSize = 1f
         // progress stands for position on the bar
-        procrastinationDetectorSlider.incrementProgressBy(preferences.getInt(
+        procrastinationDetectorSlider.value = preferences.getInt(
             PROCRASTINATION_FIGHTER_SENSITIVITY_PREF_KEY,
             ProcrastinationDetectorService.DEFAULT_SENSITIVITY
-        ))
+        ).toFloat()
     }
 
     /*
@@ -100,27 +103,11 @@ class MainSettingsActivity : AppCompatActivity() {
     }
 
     private fun setOnSeekBarChangeListener() {
-        procrastinationDetectorSlider.setOnSeekBarChangeListener(
-            object : SeekBar.OnSeekBarChangeListener {
-                override fun onProgressChanged(
-                    seekBar: SeekBar?,
-                    progress: Int,
-                    fromUser: Boolean
-                ) {
-                    if (fromUser){ // write only if from user, not when slider created
-                        writeNewSensitivityValue(progress)
-                    }
-                }
-
-                override fun onStartTrackingTouch(seekBar: SeekBar?) {
-                    /* do nothing */
-                }
-
-                override fun onStopTrackingTouch(seekBar: SeekBar?) {
-                    /* do nothing */
-                }
+        procrastinationDetectorSlider.addOnChangeListener(Slider.OnChangeListener { _, value, fromUser ->
+            if (fromUser) { // write only if from user, not when slider created
+                writeNewSensitivityValue(value.toInt())
             }
-        )
+        })
     }
 
     // sets the buttons to the state they had last time the app was stopped

--- a/app/src/main/java/com/github/multimatum_team/multimatum/service/ProcrastinationDetectorService.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/service/ProcrastinationDetectorService.kt
@@ -3,6 +3,7 @@ package com.github.multimatum_team.multimatum.service
 import android.app.*
 import android.content.Context
 import android.content.Intent
+import android.content.SharedPreferences
 import android.graphics.Color
 import android.hardware.Sensor
 import android.hardware.SensorEvent
@@ -28,6 +29,9 @@ import javax.inject.Inject
 class ProcrastinationDetectorService : Service(), SensorEventListener {
     @Inject
     lateinit var sensorManager: SensorManager
+
+    @Inject
+    lateinit var sharedPreferences: SharedPreferences
 
     private var isServiceStarted = false
     private var wakeLock: PowerManager.WakeLock? = null
@@ -69,9 +73,10 @@ class ProcrastinationDetectorService : Service(), SensorEventListener {
         return START_STICKY  // service must restart as soon as possible if preempted
     }
 
-    private fun initListenerIfNeeded(){
-        if (!this::sensorListener.isInitialized){
-            sensorListener = ProcrastinationDetectorSensorListener(applicationContext)
+    private fun initListenerIfNeeded() {
+        if (!this::sensorListener.isInitialized) {
+            sensorListener =
+                ProcrastinationDetectorSensorListener(applicationContext, sharedPreferences)
         }
     }
 
@@ -94,6 +99,7 @@ class ProcrastinationDetectorService : Service(), SensorEventListener {
         isServiceStarted = true
         acquireWakeLock()
         registerServiceAsSensorListener()
+        sensorListener.reloadSensitivity()
     }
 
     private fun registerServiceAsSensorListener() {
@@ -175,6 +181,9 @@ class ProcrastinationDetectorService : Service(), SensorEventListener {
          * The sensor used by this service to detect movements
          */
         const val REF_SENSOR = Sensor.TYPE_GRAVITY
+
+        const val MAX_SENSITIVITY = 10
+        const val DEFAULT_SENSITIVITY = 5
 
         private const val NOTIFICATION_CHANNEL_ID =
             "com.github.multimatum_team-mutlimatum.ProcrastinationDetectorServiceChannel"

--- a/app/src/main/res/layout/activity_main_settings.xml
+++ b/app/src/main/res/layout/activity_main_settings.xml
@@ -119,12 +119,13 @@
             android:textSize="@dimen/main_settings_toggle_font_size" />
 
         <LinearLayout
+            android:id="@+id/main_settings_procrastination_detector_sensibility_bar"
             android:layout_width="match_parent"
             android:layout_height="30dp"
             android:orientation="horizontal">
 
             <TextView
-                android:id="@+id/textView2"
+                android:id="@+id/main_settings_procrastination_detector_sensitivity_slider_text"
                 android:layout_width="113dp"
                 android:layout_height="match_parent"
                 android:layout_weight="1"
@@ -132,7 +133,7 @@
                 android:textSize="20sp" />
 
             <SeekBar
-                android:id="@+id/seekBar3"
+                android:id="@+id/main_settings_procrastination_detector_sensibility_slider"
                 android:layout_width="285dp"
                 android:layout_height="match_parent"
                 android:layout_weight="1" />

--- a/app/src/main/res/layout/activity_main_settings.xml
+++ b/app/src/main/res/layout/activity_main_settings.xml
@@ -117,6 +117,27 @@
             android:layout_height="wrap_content"
             android:text="@string/main_settings_enable_procrastination_fighter_button"
             android:textSize="@dimen/main_settings_toggle_font_size" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="30dp"
+            android:orientation="horizontal">
+
+            <TextView
+                android:id="@+id/textView2"
+                android:layout_width="113dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
+                android:text="@string/main_settings_procrastination_fighter_sensitivity"
+                android:textSize="20sp" />
+
+            <SeekBar
+                android:id="@+id/seekBar3"
+                android:layout_width="285dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1" />
+        </LinearLayout>
+
     </LinearLayout>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_main_settings.xml
+++ b/app/src/main/res/layout/activity_main_settings.xml
@@ -121,7 +121,7 @@
         <LinearLayout
             android:id="@+id/main_settings_procrastination_detector_sensibility_bar"
             android:layout_width="match_parent"
-            android:layout_height="30dp"
+            android:layout_height="50dp"
             android:orientation="horizontal">
 
             <TextView
@@ -129,10 +129,12 @@
                 android:layout_width="113dp"
                 android:layout_height="match_parent"
                 android:layout_weight="1"
+                android:layout_marginTop="5dp"
+                android:layout_marginStart="10dp"
                 android:text="@string/main_settings_procrastination_fighter_sensitivity"
                 android:textSize="20sp" />
 
-            <SeekBar
+            <com.google.android.material.slider.Slider
                 android:id="@+id/main_settings_procrastination_detector_sensibility_slider"
                 android:layout_width="285dp"
                 android:layout_height="match_parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -14,6 +14,7 @@
     <string name="main_settings_enable_notif_button">Enable notifications</string>
     <string name="main_settings_procrastination_fighter_section_title">Procrastination fighter</string>
     <string name="main_settings_enable_procrastination_fighter_button">Notify me when I am procrastinating</string>
+    <string name="main_settings_procrastination_fighter_sensitivity">Sensitivity</string>
     <string name="main_open_settings_but_content_descr">Settings button</string>
     <string name="isAlreadyDue">Is already Due</string>
     <string name="done">Done</string>

--- a/app/src/test/java/com/github/multimatum_team/multimatum/MainSettingsActivityTest.kt
+++ b/app/src/test/java/com/github/multimatum_team/multimatum/MainSettingsActivityTest.kt
@@ -43,7 +43,6 @@ import org.hamcrest.Description
 import org.hamcrest.Matcher
 import org.junit.After
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -135,8 +134,7 @@ class MainSettingsActivityTest {
                 eq(NOTIF_ENABLED_PREF_KEY),
                 any()
             )
-        )
-            .thenReturn(true)
+        ).thenReturn(true)
         `when`(mockSharedPreferences.getBoolean(eq(DARK_MODE_PREF_KEY), any()))
             .thenReturn(false)
         val applicationContext = ApplicationProvider.getApplicationContext<Context>()
@@ -144,24 +142,18 @@ class MainSettingsActivityTest {
         val activityScenario: ActivityScenario<MainSettingsActivity> =
             ActivityScenario.launch(intent)
         `when`(mockSharedPreferences.edit()).thenReturn(mockEditor)
-        `when`(mockEditor.apply()).then { /* do nothing */ }
-        `when`(mockEditor.putBoolean(any(), any())).then { /* do nothing */ }
-        var sensitivity = -1
-        var wasWritten: Boolean
-        `when`(mockEditor.putInt(eq(PROCRASTINATION_FIGHTER_SENSITIVITY_PREF_KEY), any()))
-            .then {
-                wasWritten = true
-                assertEquals(sensitivity, it.getArgument(1))
-                mockEditor
-            }
         activityScenario.use {
-            for (currSensitivity in (0..10).toList().shuffled()) {
-                sensitivity = currSensitivity
-                wasWritten = false
+            for (sensitivity in (1..10).toList().shuffled(Random(seed = 415L))) {
+                var writtenValue = -1
+                `when`(mockEditor.putInt(eq(PROCRASTINATION_FIGHTER_SENSITIVITY_PREF_KEY), any()))
+                    .then {
+                        writtenValue = it.getArgument(1)
+                        mockEditor
+                    }
                 onView(withId(R.id.main_settings_procrastination_detector_sensibility_slider))
                     .perform(setSliderValueAction(sensitivity))
                     .check(matches(hasValue(sensitivity)))
-                assertTrue(wasWritten)
+                assertEquals(sensitivity, writtenValue)
             }
         }
     }
@@ -199,8 +191,7 @@ class MainSettingsActivityTest {
                 eq(NOTIF_ENABLED_PREF_KEY),
                 any()
             )
-        )
-            .thenReturn(initNotifEnabled)
+        ).thenReturn(initNotifEnabled)
         `when`(mockSharedPreferences.getBoolean(eq(DARK_MODE_PREF_KEY), any()))
             .thenReturn(initDarkModeEnabled)
         val mockEditor: SharedPreferences.Editor = mock()

--- a/app/src/test/java/com/github/multimatum_team/multimatum/service/ProcrastinationDetectorServiceTest.kt
+++ b/app/src/test/java/com/github/multimatum_team/multimatum/service/ProcrastinationDetectorServiceTest.kt
@@ -12,6 +12,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.rule.ServiceTestRule
 import com.github.multimatum_team.multimatum.DependenciesProvider
 import com.github.multimatum_team.multimatum.R
+import com.github.multimatum_team.multimatum.activity.MainSettingsActivity
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -28,6 +29,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.Mockito
 import org.mockito.Mockito.`when`
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
@@ -56,6 +58,12 @@ class ProcrastinationDetectorServiceTest {
     fun init() {
         Intents.init()
         hiltRule.inject()
+        `when`(
+            mockSharedPreferences.getInt(
+                eq(MainSettingsActivity.PROCRASTINATION_FIGHTER_SENSITIVITY_PREF_KEY),
+                any()
+            )
+        ).thenReturn(PROCRASTINATION_DETECTOR_SENSITIVITY_FOR_TESTS)
     }
 
     @After
@@ -347,6 +355,8 @@ class ProcrastinationDetectorServiceTest {
         private val mockSharedPreferences: SharedPreferences = mock()
         private const val TINY_CHANGE = 1e-5.toFloat()
         private const val FAKE_TOAST_TEXT = "<fake_toast_text>"
+        private const val PROCRASTINATION_DETECTOR_SENSITIVITY_FOR_TESTS =
+            ProcrastinationDetectorService.MAX_SENSITIVITY - 2
     }
 
     @Module

--- a/app/src/test/java/com/github/multimatum_team/multimatum/service/ProcrastinationDetectorServiceTest.kt
+++ b/app/src/test/java/com/github/multimatum_team/multimatum/service/ProcrastinationDetectorServiceTest.kt
@@ -301,7 +301,7 @@ class ProcrastinationDetectorServiceTest {
         controller.destroy()
     }
 
-    data class EventToSimulate(val x: Float, val y: Float, val z: Float, val timestamp: Long)
+    private data class EventToSimulate(val x: Float, val y: Float, val z: Float, val timestamp: Long)
 
     /**
      * WARNING this method does not perform any assertion


### PR DESCRIPTION
Add a slider to the settings activity to set the sensitivity of the procrastination detector. Sensitivity determines how long the phone should be moving before a toast is issued.

Closes #217 