### PR TITLE
Feature/more patterns in parser

### DIFF
--- a/app/.gitignore
+++ b/app/.gitignore
@@ -1,2 +1,3 @@
 /build
 google-services.json
+*.ws.kts

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -120,6 +120,7 @@ dependencies {
     testImplementation 'org.mockito.kotlin:mockito-kotlin:4.0.0'
     testImplementation 'org.mockito:mockito-core:4.4.0'
     testImplementation 'com.linkedin.dexmaker:dexmaker-mockito:2.28.1'
+    implementation "org.jetbrains.kotlin:kotlin-reflect:1.6.20"
 }
 
 tasks.withType(Test) {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -121,6 +121,9 @@ dependencies {
     testImplementation 'org.mockito:mockito-core:4.4.0'
     testImplementation 'com.linkedin.dexmaker:dexmaker-mockito:2.28.1'
     implementation "org.jetbrains.kotlin:kotlin-reflect:1.6.20"
+
+    // Worksheet
+    implementation 'org.jetbrains.kotlin:kotlin-script-runtime:1.6.20'
 }
 
 tasks.withType(Test) {

--- a/app/src/main/java/com/github/multimatum_team/multimatum/model/datetime_parser/DateTimeExtractor.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/model/datetime_parser/DateTimeExtractor.kt
@@ -10,8 +10,11 @@ import java.time.LocalTime
  */
 data class PatternMatchCase(
     val pattern: List<(Token) -> Any?>,
-    val extractionFunc: (List<Any?>) -> ExtractedInfo?
-)
+    val extractionFunc: (List<Any?>) -> ExtractedInfo?,
+    val name: String
+){
+    override fun toString(): String = name
+}
 
 /**
  * Contains the info extracted by parsing

--- a/app/src/main/java/com/github/multimatum_team/multimatum/model/datetime_parser/DateTimePatternsGenerator.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/model/datetime_parser/DateTimePatternsGenerator.kt
@@ -1,6 +1,5 @@
 package com.github.multimatum_team.multimatum.model.datetime_parser
 
-import com.github.multimatum_team.multimatum.LogUtil
 import java.time.*
 import java.time.temporal.TemporalAdjusters
 import kotlin.reflect.full.findAnnotation
@@ -220,15 +219,20 @@ class DateTimePatternsGenerator(private val currentDateProvider: () -> LocalDate
             timeFor(0, 0)
         }
 
+    // all the patterns, i.e. all the properties marked with @PatternPair
     val patterns: List<PatternMatchCase> =
         @Suppress("UNCHECKED_CAST")
+        /* Cannot check the type parameters in cast
+         * This may cause a crash when this class is instantiated if @PatternPair is used
+         * on something else than the type given in its documentation */
         this::class.memberProperties
             .filter { it.findAnnotation<PatternPair>() != null }
             .map {
                 it.getter.isAccessible = true
-                val (pattern, extractionFunc) = it.getter.call(this) as Pair<List<(Token) -> Any?>, (List<Any?>) -> ExtractedInfo>
+                val (pattern, extractionFunc) = it.getter.call(this)
+                        as Pair<List<(Token) -> Any?>, (List<Any?>) -> ExtractedInfo>
                 it.getter.isAccessible = false
-                PatternMatchCase(pattern, extractionFunc)
+                PatternMatchCase(pattern, extractionFunc, it.name)
             }
 
 }

--- a/app/src/main/java/com/github/multimatum_team/multimatum/model/datetime_parser/DateTimePatternsGenerator.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/model/datetime_parser/DateTimePatternsGenerator.kt
@@ -325,6 +325,14 @@ class DateTimePatternsGenerator(private val currentDateProvider: () -> LocalDate
             timeFor(0, 0)
         }
 
+    @PatternPair
+    private val tomorrow =
+        listOf(
+            tokenMatchingOneOf("tomorrow")
+        ) to { _: List<Any?> ->
+            ExtractedDate(currentDateProvider().plusDays(1))
+        }
+
     // all the patterns, i.e. all the properties marked with @PatternPair
     val patterns: List<PatternMatchCase> =
         @Suppress("UNCHECKED_CAST")

--- a/app/src/main/java/com/github/multimatum_team/multimatum/model/datetime_parser/DateTimePatternsGenerator.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/model/datetime_parser/DateTimePatternsGenerator.kt
@@ -266,7 +266,7 @@ class DateTimePatternsGenerator(private val currentDateProvider: () -> LocalDate
         }
 
     @PatternPair
-    private val January_1 =
+    private val `January-1` =
         listOf(
             Token::asMonth,
             dateSeparator,

--- a/app/src/main/java/com/github/multimatum_team/multimatum/model/datetime_parser/DateTimePatternsGenerator.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/model/datetime_parser/DateTimePatternsGenerator.kt
@@ -89,10 +89,10 @@ class DateTimePatternsGenerator(private val currentDateProvider: () -> LocalDate
 
         fun compareTo(other: PossiblyInvalidDate): Int {
             val (otherDay, otherMonth, otherYear) = other
-            val compDay = day.compareTo(otherDay)
+            fun compDay() = day.compareTo(otherDay)
             fun compMonth() = month.compareTo(otherMonth)
             fun compYear() = year.compareTo(otherYear)
-            return sequenceOf(compDay, compMonth(), compYear())
+            return sequenceOf(compYear(), compMonth(), compDay())
                 .firstOrNull { it != 0 } ?: 0
         }
 
@@ -119,12 +119,14 @@ class DateTimePatternsGenerator(private val currentDateProvider: () -> LocalDate
     private fun dateForIfExistsInferringYear(month: Month, day: Int): ExtractedDate? {
         // dates may not be valid, so do not use LocalDate
         val currDate = currentDateProvider()
-        val requiredDayThisYear = PossiblyInvalidDate(currDate.year, month, day)
+        val requiredDayThisYear =
+            PossiblyInvalidDate(year = currDate.year, month = month, day = day)
         val targetDate =
-            if (requiredDayThisYear >= currDate) requiredDayThisYear else PossiblyInvalidDate(
-                currDate.year + 1,
-                month,
-                day
+            if (requiredDayThisYear >= currDate) requiredDayThisYear
+            else PossiblyInvalidDate(
+                day = day,
+                month = month,
+                year = currDate.year + 1
             )
         return dateForIfExists(
             year = targetDate.year,

--- a/app/src/main/java/com/github/multimatum_team/multimatum/model/datetime_parser/Tokens.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/model/datetime_parser/Tokens.kt
@@ -44,9 +44,6 @@ sealed class Token {
 
     open fun asDayOfWeek(): DayOfWeek? = null
 
-    open fun asDateSeparator(): Token? = null
-    open fun asTimeSeparator(): Token? = null
-
     fun strWithWhitespaceIfNeeded(): String =
         if (followedByWhitespace) "$str "
         else str
@@ -59,8 +56,6 @@ sealed class Token {
 data class AlphabeticToken(override val str: String) : Token() {
     override fun asDayOfWeek(): DayOfWeek? =
         DayOfWeek.values().find { it.name equalsIgnoreCase str }
-
-    override fun asTimeSeparator(): Token? = if (str == "h") this else null
 
     override fun asMonth(): Month? =
         Month.values().find {
@@ -98,12 +93,7 @@ data class SymbolToken(override val str: String) : Token() {
         require(str.length == 1)
     }
 
-    private val dateSeparators = listOf('.', '/', '-')
-
     val charValue: Char get() = str[0]
-
-    override fun asDateSeparator(): Token? = if (dateSeparators.contains(charValue)) this else null
-    override fun asTimeSeparator(): Token? = if (charValue == ':') this else null
 }
 
 /**

--- a/app/src/main/java/com/github/multimatum_team/multimatum/model/datetime_parser/Tokens.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/model/datetime_parser/Tokens.kt
@@ -60,6 +60,8 @@ data class AlphabeticToken(override val str: String) : Token() {
     override fun asDayOfWeek(): DayOfWeek? =
         DayOfWeek.values().find { it.name equalsIgnoreCase str }
 
+    override fun asTimeSeparator(): Token? = if (str == "h") this else null
+
     override fun asMonth(): Month? =
         Month.values().find {
             it.name equalsIgnoreCase str  // match full month name (e.g. march)
@@ -97,12 +99,11 @@ data class SymbolToken(override val str: String) : Token() {
     }
 
     private val dateSeparators = listOf('.', '/', '-')
-    private val timeSeparators = listOf(':', 'h')
 
     val charValue: Char get() = str[0]
 
     override fun asDateSeparator(): Token? = if (dateSeparators.contains(charValue)) this else null
-    override fun asTimeSeparator(): Token? = if (timeSeparators.contains(charValue)) this else null
+    override fun asTimeSeparator(): Token? = if (charValue == ':') this else null
 }
 
 /**

--- a/app/src/test/java/com/github/multimatum_team/multimatum/DateTimeExtractorTest.kt
+++ b/app/src/test/java/com/github/multimatum_team/multimatum/DateTimeExtractorTest.kt
@@ -202,4 +202,24 @@ class DateTimeExtractorTest {
         assertFound(expText, expTime = LocalTime.MIDNIGHT)(actualRes)
     }
 
+    @Test
+    fun tomorrow_is_parsed_correctly(){
+        val str = "Due homework tomorrow"
+        val expText = "Due homework"
+        val currentDate = LocalDate.of(2020, 4, 4)
+        val expectedDate = LocalDate.of(2020, 4, 5)
+        val extractor = DateTimeExtractor { currentDate }
+        assertFound(expText, expDate = expectedDate)(extractor.parse(str))
+    }
+
+    @Test
+    fun may_3rd_is_parsed_correctly(){
+        val str = "Report May 3rd"
+        val expText = "Report"
+        val currDate = LocalDate.of(2021, Month.MARCH, 17)
+        val expectedDate = LocalDate.of(2021, Month.MAY, 3)
+        val extractor = DateTimeExtractor { currDate }
+        assertFound(expText, expDate = expectedDate)(extractor.parse(str))
+    }
+
 }

--- a/app/src/test/java/com/github/multimatum_team/multimatum/DateTimeExtractorTest.kt
+++ b/app/src/test/java/com/github/multimatum_team/multimatum/DateTimeExtractorTest.kt
@@ -37,7 +37,7 @@ class DateTimeExtractorTest {
     }
 
     @Test
-    fun `18h_is_parsed_correctly`(){
+    fun `18h_is_parsed_correctly`() {
         val str = "Geography 18h"
         val expText = "Geography"
         val actualRes = DEFAULT_DATE_TIME_EXTRACTOR.parse(str)
@@ -187,7 +187,7 @@ class DateTimeExtractorTest {
     }
 
     @Test
-    fun midday_is_parsed_correctly(){
+    fun midday_is_parsed_correctly() {
         val str = "Lunch at noon"
         val expText = "Lunch"
         val actualRes = DEFAULT_DATE_TIME_EXTRACTOR.parse(str)
@@ -195,7 +195,7 @@ class DateTimeExtractorTest {
     }
 
     @Test
-    fun midnight_is_parsed_correctly(){
+    fun midnight_is_parsed_correctly() {
         val str = "Due work at midnight"
         val expText = "Due work"
         val actualRes = DEFAULT_DATE_TIME_EXTRACTOR.parse(str)
@@ -203,7 +203,7 @@ class DateTimeExtractorTest {
     }
 
     @Test
-    fun tomorrow_is_parsed_correctly(){
+    fun tomorrow_is_parsed_correctly() {
         val str = "Due homework tomorrow"
         val expText = "Due homework"
         val currentDate = LocalDate.of(2020, 4, 4)
@@ -213,13 +213,67 @@ class DateTimeExtractorTest {
     }
 
     @Test
-    fun may_3rd_is_parsed_correctly(){
+    fun may_3rd_is_parsed_correctly() {
         val str = "Report May 3rd"
         val expText = "Report"
         val currDate = LocalDate.of(2021, Month.MARCH, 17)
         val expectedDate = LocalDate.of(2021, Month.MAY, 3)
         val extractor = DateTimeExtractor { currDate }
         assertFound(expText, expDate = expectedDate)(extractor.parse(str))
+    }
+
+    @Test
+    fun `may-3_is_parsed_correctly`() {
+        val str = "Report May-3"
+        val expText = "Report"
+        val currDate = LocalDate.of(2021, Month.MARCH, 17)
+        val expectedDate = LocalDate.of(2021, Month.MAY, 3)
+        val extractor = DateTimeExtractor { currDate }
+        assertFound(expText, expDate = expectedDate)(extractor.parse(str))
+    }
+
+    @Test
+    fun `3dot12_is_parsed_correctly`() {
+        val str = "Something to submit 3.14"
+        val expText = "Something to submit"
+        val currDate = LocalDate.of(2021, Month.JANUARY, 10)
+        val expectedDate = LocalDate.of(2021, Month.MARCH, 14)
+        val extractor = DateTimeExtractor { currDate }
+        assertFound(expText, expDate = expectedDate)(extractor.parse(str))
+    }
+
+    @Test
+    fun `12dot3_is_parsed_correctly`() {
+        val str = "Something to submit 14.3"
+        val expText = "Something to submit"
+        val currDate = LocalDate.of(2021, Month.JANUARY, 10)
+        val expectedDate = LocalDate.of(2021, Month.MARCH, 14)
+        val extractor = DateTimeExtractor { currDate }
+        assertFound(expText, expDate = expectedDate)(extractor.parse(str))
+    }
+
+    @Test
+    fun `11h45am_is_parsed_correctly`() {
+        val str = "Apero at 11h45am"
+        val expText = "Apero"
+        val expectedTime = LocalTime.of(11, 45)
+        assertFound(expText, expTime = expectedTime)(DEFAULT_DATE_TIME_EXTRACTOR.parse(str))
+    }
+
+    @Test
+    fun `7h27pm_is_parsed_correctly`() {
+        val str = "Apero at 7h27pm"
+        val expText = "Apero"
+        val expectedTime = LocalTime.of(19, 27)
+        assertFound(expText, expTime = expectedTime)(DEFAULT_DATE_TIME_EXTRACTOR.parse(str))
+    }
+
+    @Test
+    fun `2022_2_27_is_parsed_correctly`(){
+        val str = "ToDo 2022 2 27"
+        val expText = "ToDo"
+        val expectedDate = LocalDate.of(2022, Month.FEBRUARY, 27)
+        assertFound(expText, expDate = expectedDate)(DEFAULT_DATE_TIME_EXTRACTOR.parse(str))
     }
 
 }


### PR DESCRIPTION
Implemented:
* new patterns for the parser
   close #218
* patterns are now marked using an annotation instead of having to add them to a list (which is error-prone)
   close #243 
* bug with pattern "15h00" matching only "15h" is fixed (problem was that the parser was looking for "h" as a `SymbolToken`, but it is actually an `AlphabeticToken`)
   close #245 
