### PR TITLE
Group invites

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -65,6 +65,7 @@ dependencies {
     implementation 'com.google.android.gms:play-services-auth:20.2.0'
     implementation 'com.google.android.gms:play-services-base:18.0.1'
     implementation 'com.google.firebase:firebase-inappmessaging:20.1.2'
+    implementation 'com.google.firebase:firebase-dynamic-links-ktx:21.0.1'
     implementation 'com.google.dagger:hilt-android:2.41'
     implementation platform("org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.6.0")
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -70,6 +70,19 @@
             </intent-filter>
         </activity>
 
+        <activity
+            android:name=".activity.GroupInviteActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+                <data
+                    android:host="multimatum.page.link"
+                    android:scheme="https"/>
+            </intent-filter>
+        </activity>
+
         <receiver android:name=".ReminderBroadcastReceiver" />
     </application>
 

--- a/app/src/main/java/com/github/multimatum_team/multimatum/DependenciesProvider.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/DependenciesProvider.kt
@@ -9,6 +9,7 @@ import com.github.multimatum_team.multimatum.repository.*
 import com.github.multimatum_team.multimatum.service.ClockService
 import com.github.multimatum_team.multimatum.service.SystemClockService
 import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.dynamiclinks.FirebaseDynamicLinks
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.storage.FirebaseStorage
 import dagger.Binds
@@ -60,6 +61,15 @@ object FirebaseModule {
     @Provides
     fun provideFirebaseStorage(): FirebaseStorage =
         FirebaseStorage.getInstance()
+}
+
+@Module
+@InstallIn(SingletonComponent::class)
+object FirebaseDynamicLinksModule {
+    @Singleton
+    @Provides
+    fun provideFirebaseDynamicLinks(): FirebaseDynamicLinks =
+        FirebaseDynamicLinks.getInstance()
 }
 
 @Module

--- a/app/src/main/java/com/github/multimatum_team/multimatum/activity/GroupDetailsActivity.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/activity/GroupDetailsActivity.kt
@@ -1,16 +1,14 @@
 package com.github.multimatum_team.multimatum.activity
 
 import android.app.AlertDialog
-import android.content.Context
-import android.content.DialogInterface
-import android.content.Intent
-import android.content.SharedPreferences
+import android.content.*
 import android.os.Bundle
 import android.text.SpannableStringBuilder
 import android.view.MotionEvent
 import android.view.View
 import android.widget.Button
 import android.widget.TextView
+import android.widget.Toast
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -76,6 +74,7 @@ class GroupDetailsActivity : AppCompatActivity() {
         // Initialize UI widgets
         initTextInput()
         initGroupMemberView()
+        initInviteButton()
         initLeaveButton()
     }
 
@@ -140,6 +139,24 @@ class GroupDetailsActivity : AppCompatActivity() {
     }
 
     /**
+     * Generate invite link for the current group and store it in a clipboard.
+     */
+    private fun initInviteButton() {
+        groupInviteButton.setOnClickListener {
+            groupViewModel.generateInviteLink(groupID) { inviteLink ->
+                val clipboard: ClipboardManager =
+                    getSystemService(CLIPBOARD_SERVICE) as ClipboardManager
+                val clip =
+                    ClipData.newPlainText("Invite link to ${groupNameView.text}", inviteLink.toString())
+                clipboard.setPrimaryClip(clip)
+                Toast
+                    .makeText(this, "Copied invite link to clipboard", Toast.LENGTH_SHORT)
+                    .show()
+            }
+        }
+    }
+
+    /**
      * Initialize groupDeleteOrLeaveButton with the right text and leave the group when clicked.
      */
     private fun initLeaveButton() {
@@ -170,11 +187,11 @@ class GroupDetailsActivity : AppCompatActivity() {
             AlertDialog.Builder(this)
                 .setMessage(getString(R.string.group_delete_confirmation_dialog))
                 .setPositiveButton(getString(R.string.group_delete_dialog_confirm)) { dialog, _ ->
-                        dialog.dismiss()
-                        groupViewModel.deleteGroup(groupID)
-                        finish()
+                    dialog.dismiss()
+                    groupViewModel.deleteGroup(groupID)
+                    finish()
                 }.setNegativeButton(getString(R.string.group_delete_dialog_cancel)) { dialog, _ ->
-                        dialog.dismiss()
+                    dialog.dismiss()
                 }.show()
         }
     }

--- a/app/src/main/java/com/github/multimatum_team/multimatum/activity/GroupInviteActivity.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/activity/GroupInviteActivity.kt
@@ -6,20 +6,24 @@ import android.widget.Button
 import android.widget.TextView
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
+import com.github.multimatum_team.multimatum.LogUtil
 import com.github.multimatum_team.multimatum.R
 import com.github.multimatum_team.multimatum.model.GroupID
 import com.github.multimatum_team.multimatum.model.SignedInUser
 import com.github.multimatum_team.multimatum.viewmodel.AuthViewModel
 import com.github.multimatum_team.multimatum.viewmodel.GroupViewModel
-import com.google.firebase.dynamiclinks.ktx.dynamicLinks
-import com.google.firebase.ktx.Firebase
+import com.google.firebase.dynamiclinks.FirebaseDynamicLinks
 import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
 /**
  *  Activity to accept or deny group invites.
  */
 @AndroidEntryPoint
 class GroupInviteActivity : AppCompatActivity() {
+    @Inject
+    lateinit var dynamicLinks: FirebaseDynamicLinks
+
     private val authViewModel: AuthViewModel by viewModels()
     private val groupViewModel: GroupViewModel by viewModels()
 
@@ -34,6 +38,8 @@ class GroupInviteActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_group_invite)
 
+        LogUtil.debugLog(intent.toString())
+
         inviteMessageView = findViewById(R.id.group_invite_message)
         groupNameView = findViewById(R.id.group_invite_name)
         acceptButton = findViewById(R.id.group_invite_accept)
@@ -46,7 +52,7 @@ class GroupInviteActivity : AppCompatActivity() {
         when (val user = authViewModel.getUser().value) {
             is SignedInUser -> {
                 currentUser = user
-                Firebase.dynamicLinks
+                dynamicLinks
                     .getDynamicLink(intent)
                     .addOnSuccessListener(this) { pendingDynamicLinkData ->
                         when (val link = pendingDynamicLinkData?.link) {
@@ -68,22 +74,29 @@ class GroupInviteActivity : AppCompatActivity() {
     }
 
     private fun initSignInRequirementMessage() {
+        println("initSignInRequirementMessage")
         inviteMessageView.text = getString(R.string.group_invite_message_must_be_signed_in)
     }
 
     private fun initInvalidLink() {
+        println("initInvalidLink")
         inviteMessageView.text = getString(R.string.group_invite_message_invalid)
     }
 
     private fun initValidLink(groupID: GroupID) {
+        println("initValidLink")
         groupViewModel.fetchNewGroup(groupID) { group ->
             if (group == null) {
+                println("group == null")
                 inviteMessageView.text = getString(R.string.group_invite_message_invalid)
             } else {
+                println("group != null")
                 if (group.members.contains(currentUser.id)) {
+                    println(getString(R.string.group_invite_message_already_member_of_this_group))
                     inviteMessageView.text =
                         getString(R.string.group_invite_message_already_member_of_this_group)
                 } else {
+                    println(getString(R.string.group_invite_message_you_have_been_invited_to_join))
                     inviteMessageView.text =
                         getString(R.string.group_invite_message_you_have_been_invited_to_join)
                     groupNameView.text = group.name

--- a/app/src/main/java/com/github/multimatum_team/multimatum/activity/GroupInviteActivity.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/activity/GroupInviteActivity.kt
@@ -1,0 +1,35 @@
+package com.github.multimatum_team.multimatum.activity
+
+import android.net.Uri
+import android.os.Bundle
+import android.util.Log
+import androidx.appcompat.app.AppCompatActivity
+import com.github.multimatum_team.multimatum.LogUtil
+import com.github.multimatum_team.multimatum.R
+import com.google.firebase.dynamiclinks.ktx.dynamicLinks
+import com.google.firebase.ktx.Firebase
+import dagger.hilt.android.AndroidEntryPoint
+
+/**
+ *  Activity to accept or deny group invites.
+ */
+@AndroidEntryPoint
+class GroupInviteActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_group_invite)
+
+        Firebase.dynamicLinks
+            .getDynamicLink(intent)
+            .addOnSuccessListener(this) { pendingDynamicLinkData ->
+                // Get deep link from result (may be null if no link is found)
+                var deepLink: Uri? = null
+                if (pendingDynamicLinkData != null) {
+                    deepLink = pendingDynamicLinkData.link
+                }
+
+                LogUtil.debugLog(deepLink.toString())
+            }
+            .addOnFailureListener(this) { e -> Log.w("GroupInviteActivity", "getDynamicLink:onFailure", e) }
+    }
+}

--- a/app/src/main/java/com/github/multimatum_team/multimatum/activity/GroupInviteActivity.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/activity/GroupInviteActivity.kt
@@ -1,11 +1,16 @@
 package com.github.multimatum_team.multimatum.activity
 
-import android.net.Uri
 import android.os.Bundle
-import android.util.Log
+import android.view.View
+import android.widget.Button
+import android.widget.TextView
+import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
-import com.github.multimatum_team.multimatum.LogUtil
 import com.github.multimatum_team.multimatum.R
+import com.github.multimatum_team.multimatum.model.GroupID
+import com.github.multimatum_team.multimatum.model.SignedInUser
+import com.github.multimatum_team.multimatum.viewmodel.AuthViewModel
+import com.github.multimatum_team.multimatum.viewmodel.GroupViewModel
 import com.google.firebase.dynamiclinks.ktx.dynamicLinks
 import com.google.firebase.ktx.Firebase
 import dagger.hilt.android.AndroidEntryPoint
@@ -15,21 +20,85 @@ import dagger.hilt.android.AndroidEntryPoint
  */
 @AndroidEntryPoint
 class GroupInviteActivity : AppCompatActivity() {
+    private val authViewModel: AuthViewModel by viewModels()
+    private val groupViewModel: GroupViewModel by viewModels()
+
+    private lateinit var inviteMessageView: TextView
+    private lateinit var groupNameView: TextView
+    private lateinit var acceptButton: Button
+    private lateinit var denyButton: Button
+
+    private lateinit var currentUser: SignedInUser
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_group_invite)
 
-        Firebase.dynamicLinks
-            .getDynamicLink(intent)
-            .addOnSuccessListener(this) { pendingDynamicLinkData ->
-                // Get deep link from result (may be null if no link is found)
-                var deepLink: Uri? = null
-                if (pendingDynamicLinkData != null) {
-                    deepLink = pendingDynamicLinkData.link
-                }
+        inviteMessageView = findViewById(R.id.group_invite_message)
+        groupNameView = findViewById(R.id.group_invite_name)
+        acceptButton = findViewById(R.id.group_invite_accept)
+        denyButton = findViewById(R.id.group_invite_deny)
 
-                LogUtil.debugLog(deepLink.toString())
+        groupNameView.visibility = View.INVISIBLE
+        acceptButton.visibility = View.INVISIBLE
+        denyButton.visibility = View.INVISIBLE
+
+        when (val user = authViewModel.getUser().value) {
+            is SignedInUser -> {
+                currentUser = user
+                Firebase.dynamicLinks
+                    .getDynamicLink(intent)
+                    .addOnSuccessListener(this) { pendingDynamicLinkData ->
+                        when (val link = pendingDynamicLinkData?.link) {
+                            null -> initInvalidLink()
+                            else -> {
+                                when (val groupID = link.getQueryParameter("id")) {
+                                    null -> initInvalidLink()
+                                    else -> initValidLink(groupID)
+                                }
+                            }
+                        }
+                    }
+                    .addOnFailureListener(this) { e ->
+                        initInvalidLink()
+                    }
             }
-            .addOnFailureListener(this) { e -> Log.w("GroupInviteActivity", "getDynamicLink:onFailure", e) }
+            else -> initSignInRequirementMessage()
+        }
+    }
+
+    private fun initSignInRequirementMessage() {
+        inviteMessageView.text = getString(R.string.group_invite_message_must_be_signed_in)
+    }
+
+    private fun initInvalidLink() {
+        inviteMessageView.text = getString(R.string.group_invite_message_invalid)
+    }
+
+    private fun initValidLink(groupID: GroupID) {
+        groupViewModel.fetchNewGroup(groupID) { group ->
+            if (group == null) {
+                inviteMessageView.text = getString(R.string.group_invite_message_invalid)
+            } else {
+                if (group.members.contains(currentUser.id)) {
+                    inviteMessageView.text =
+                        getString(R.string.group_invite_message_already_member_of_this_group)
+                } else {
+                    inviteMessageView.text =
+                        getString(R.string.group_invite_message_you_have_been_invited_to_join)
+                    groupNameView.text = group.name
+                    groupNameView.visibility = View.VISIBLE
+                    acceptButton.visibility = View.VISIBLE
+                    denyButton.visibility = View.VISIBLE
+                    acceptButton.setOnClickListener {
+                        groupViewModel.addMember(groupID, currentUser.id)
+                        val intent = GroupDetailsActivity.newIntent(this, groupID)
+                        startActivity(intent)
+                        finish()
+                    }
+                    denyButton.setOnClickListener { finish() }
+                }
+            }
+        }
     }
 }

--- a/app/src/main/java/com/github/multimatum_team/multimatum/repository/FirebaseGroupRepository.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/repository/FirebaseGroupRepository.kt
@@ -1,12 +1,18 @@
 package com.github.multimatum_team.multimatum.repository
 
+import android.net.Uri
 import android.util.Log
+import com.github.multimatum_team.multimatum.LogUtil
 import com.github.multimatum_team.multimatum.model.GroupID
 import com.github.multimatum_team.multimatum.model.UserGroup
 import com.github.multimatum_team.multimatum.model.UserID
+import com.google.firebase.dynamiclinks.ktx.androidParameters
+import com.google.firebase.dynamiclinks.ktx.dynamicLink
+import com.google.firebase.dynamiclinks.ktx.dynamicLinks
 import com.google.firebase.firestore.DocumentSnapshot
 import com.google.firebase.firestore.FieldValue
 import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.ktx.Firebase
 import kotlinx.coroutines.tasks.await
 import javax.inject.Inject
 
@@ -114,7 +120,15 @@ class FirebaseGroupRepository @Inject constructor(database: FirebaseFirestore) :
      * @param email the email of the user to invite
      */
     override suspend fun invite(id: GroupID, email: String) {
-        throw NotImplementedError("FirebaseGroupRepository.invite is not implemented")
+        val dynamicLink = Firebase.dynamicLinks.dynamicLink {
+            link = Uri.parse("https://multimatum.page.link/")
+            domainUriPrefix = "https://multimatum.page.link"
+            // Open links with this app on Android
+            androidParameters { }
+        }
+
+        val dynamicLinkUri = dynamicLink.uri
+        LogUtil.debugLog(dynamicLinkUri.toString())
     }
 
     /**

--- a/app/src/main/java/com/github/multimatum_team/multimatum/repository/GroupRepository.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/repository/GroupRepository.kt
@@ -1,6 +1,8 @@
 package com.github.multimatum_team.multimatum.repository
 
+import android.net.Uri
 import com.github.multimatum_team.multimatum.model.GroupID
+import com.github.multimatum_team.multimatum.model.SignedInUser
 import com.github.multimatum_team.multimatum.model.UserGroup
 import com.github.multimatum_team.multimatum.model.UserID
 
@@ -60,11 +62,17 @@ abstract class GroupRepository {
     abstract suspend fun rename(id: GroupID, newName: String)
 
     /**
-     * Invite an user to a group.
-     * @param id the ID of the group to which we want to invite the new user
-     * @param email the email of the user to invite
+     * Generate an invite link to join a group given by its ID
+     * @param id the ID of the group for which to generate the invite link
      */
-    abstract suspend fun invite(id: GroupID, email: String)
+    abstract suspend fun generateInviteLink(id: GroupID): Uri
+
+    /**
+     * Add a user from a group.
+     * @param groupID the group to which to add the user
+     * @param memberID the ID of the new group member
+     */
+    abstract suspend fun addMember(groupID: GroupID, memberID: UserID)
 
     /**
      * Kick a user from a group.

--- a/app/src/main/java/com/github/multimatum_team/multimatum/viewmodel/GroupViewModel.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/viewmodel/GroupViewModel.kt
@@ -1,5 +1,6 @@
 package com.github.multimatum_team.multimatum.viewmodel
 
+import android.net.Uri
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -83,6 +84,14 @@ class GroupViewModel @Inject constructor(
         _groups.value!![id]!!
 
     /**
+     * Ask the repository to fetch a group which the current user is possibly not a member of.
+     */
+    fun fetchNewGroup(id: GroupID, callback: (UserGroup?) -> Unit) =
+        viewModelScope.launch {
+            callback(groupRepository.fetch(id))
+        }
+
+    /**
      * Add a new group to the repository.
      * @param name the name of the new group to create
      * @param callback what to do when the group creation is complete
@@ -116,18 +125,20 @@ class GroupViewModel @Inject constructor(
         LogUtil.debugLog("renaming group with id $id to $newName")
     }
 
+    fun addMember(groupID: GroupID, memberID: UserID) = viewModelScope.launch {
+        groupRepository.addMember(groupID, memberID)
+    }
+
     fun removeMember(groupID: GroupID, memberID: UserID) = viewModelScope.launch {
         groupRepository.removeMember(groupID, memberID)
     }
 
     /**
-     * Invite an user to join a group given from its ID.
-     * @param id the ID of the group to which we want to invite the user
-     * @param email the email of the user to invite
+     * Generate invite link to join a group given from its ID.
+     * @param id the ID of the group to which we want to invite users
      */
-    fun inviteUser(id: GroupID, email: String) =
+    fun generateInviteLink(id: GroupID, callback: (Uri) -> Unit) =
         viewModelScope.launch {
-            groupRepository.invite(id, email)
-            LogUtil.debugLog("inviting user with email $email to group with id $id")
+            callback(groupRepository.generateInviteLink(id))
         }
 }

--- a/app/src/main/res/layout/activity_group_invite.xml
+++ b/app/src/main/res/layout/activity_group_invite.xml
@@ -6,57 +6,53 @@
     android:layout_height="match_parent">
 
     <Button
-        android:id="@+id/invite_deny"
+        android:id="@+id/group_invite_deny"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="140dp"
-        android:text="Deny"
+        android:text="@string/group_invite_deny"
+        android:visibility="invisible"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.5"
-        app:layout_constraintStart_toEndOf="@+id/invite_accept"
-        app:layout_constraintTop_toBottomOf="@+id/invite_group_name"
+        app:layout_constraintStart_toEndOf="@+id/group_invite_accept"
+        app:layout_constraintTop_toBottomOf="@+id/group_invite_name"
         app:layout_constraintVertical_bias="0.254" />
 
     <Button
-        android:id="@+id/invite_accept"
+        android:id="@+id/group_invite_accept"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="140dp"
-        android:text="Accept"
+        android:text="@string/group_invite_accept"
+        android:visibility="invisible"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toStartOf="@+id/invite_deny"
+        app:layout_constraintEnd_toStartOf="@+id/group_invite_deny"
         app:layout_constraintHorizontal_bias="0.5"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/invite_group_name"
+        app:layout_constraintTop_toBottomOf="@+id/group_invite_name"
         app:layout_constraintVertical_bias="0.258" />
 
     <TextView
-        android:id="@+id/invite_author"
+        android:id="@+id/group_invite_name"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="TextView"
-        app:layout_constraintBottom_toTopOf="@+id/invite_group_name"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
-
-    <TextView
-        android:id="@+id/invite_group_name"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginBottom="432dp"
-        android:text="TextView"
+        android:layout_marginBottom="608dp"
+        android:textAppearance="@style/TextAppearance.AppCompat.Large"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.518"
-        app:layout_constraintStart_toStartOf="parent" />
+        app:layout_constraintHorizontal_bias="0.498"
+        app:layout_constraintStart_toStartOf="parent"
+        tools:visibility="invisible" />
 
-    <androidx.constraintlayout.widget.Barrier
-        android:id="@+id/invite_button_barrier"
+    <TextView
+        android:id="@+id/group_invite_message"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        app:barrierDirection="top"
-        tools:layout_editor_absoluteY="731dp" />
+        app:layout_constraintBottom_toTopOf="@+id/group_invite_name"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.816" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_group_invite.xml
+++ b/app/src/main/res/layout/activity_group_invite.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <Button
+        android:id="@+id/invite_deny"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="140dp"
+        android:text="Deny"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.5"
+        app:layout_constraintStart_toEndOf="@+id/invite_accept"
+        app:layout_constraintTop_toBottomOf="@+id/invite_group_name"
+        app:layout_constraintVertical_bias="0.254" />
+
+    <Button
+        android:id="@+id/invite_accept"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="140dp"
+        android:text="Accept"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/invite_deny"
+        app:layout_constraintHorizontal_bias="0.5"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/invite_group_name"
+        app:layout_constraintVertical_bias="0.258" />
+
+    <TextView
+        android:id="@+id/invite_author"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="TextView"
+        app:layout_constraintBottom_toTopOf="@+id/invite_group_name"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/invite_group_name"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="432dp"
+        android:text="TextView"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.518"
+        app:layout_constraintStart_toStartOf="parent" />
+
+    <androidx.constraintlayout.widget.Barrier
+        android:id="@+id/invite_button_barrier"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:barrierDirection="top"
+        tools:layout_editor_absoluteY="731dp" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -72,4 +72,10 @@
     <string name="group_delete_dialog_cancel">Cancel</string>
     <string name="group_delete_confirmation_dialog">Are you sure you want to delete this group?</string>
     <string name="parsing_validation_title">Your title can be parse to :</string>
+    <string name="group_invite_deny">Deny</string>
+    <string name="group_invite_accept">Accept</string>
+    <string name="group_invite_message_you_have_been_invited_to_join">You have been invited to join the group</string>
+    <string name="group_invite_message_must_be_signed_in">You have been invited to join the group</string>
+    <string name="group_invite_message_already_member_of_this_group">You are already a member of this group</string>
+    <string name="group_invite_message_invalid">Invite link is invalid, ask for a new one</string>
 </resources>

--- a/app/src/test/java/com/github/multimatum_team/multimatum/GroupInviteActivityTest.kt
+++ b/app/src/test/java/com/github/multimatum_team/multimatum/GroupInviteActivityTest.kt
@@ -1,0 +1,289 @@
+package com.github.multimatum_team.multimatum
+
+import android.arch.core.executor.testing.InstantTaskExecutorRule
+import android.content.Intent
+import android.net.Uri
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.intent.Intents
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.multimatum_team.multimatum.activity.GroupInviteActivity
+import com.github.multimatum_team.multimatum.model.GroupID
+import com.github.multimatum_team.multimatum.model.SignedInUser
+import com.github.multimatum_team.multimatum.model.UserGroup
+import com.github.multimatum_team.multimatum.model.UserInfo
+import com.github.multimatum_team.multimatum.repository.*
+import com.github.multimatum_team.multimatum.service.ClockService
+import com.github.multimatum_team.multimatum.util.*
+import com.google.firebase.dynamiclinks.FirebaseDynamicLinks
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import dagger.hilt.android.testing.UninstallModules
+import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.hamcrest.CoreMatchers.hasItem
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.not
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TestRule
+import org.junit.runner.RunWith
+import java.time.LocalDateTime
+import javax.inject.Inject
+import javax.inject.Singleton
+
+
+/**
+ * Tests for the GroupInviteActivity class
+ */
+@UninstallModules(
+    FirebaseRepositoryModule::class,
+    FirebaseDynamicLinksModule::class,
+    ClockModule::class
+)
+@HiltAndroidTest
+@RunWith(AndroidJUnit4::class)
+@ExperimentalCoroutinesApi
+class GroupInviteActivityTest {
+    @get:Rule
+    var hiltRule = HiltAndroidRule(this)
+
+    @get:Rule
+    val executorRule: TestRule = InstantTaskExecutorRule()
+
+    @Inject
+    lateinit var groupRepository: GroupRepository
+
+    @Inject
+    lateinit var authRepository: AuthRepository
+
+    @Inject
+    lateinit var userRepository: UserRepository
+
+    companion object {
+        private val joseph = SignedInUser(
+            "Joseph",
+            "Joseph",
+            "unemail@jsp.com"
+        )
+
+        private val louis = SignedInUser(
+            "Louis",
+            "Louis",
+            "louis@mit.edu"
+        )
+    }
+
+    @Before
+    @Throws(Exception::class)
+    fun setUp() {
+        Intents.init()
+        hiltRule.inject()
+    }
+
+    @After
+    fun teardown() {
+        Intents.release()
+    }
+
+    private suspend fun groupInviteIntent(groupID: GroupID): Intent {
+        val intent =
+            Intent(ApplicationProvider.getApplicationContext(), GroupInviteActivity::class.java)
+        intent.action = Intent.ACTION_VIEW
+        intent.data = groupRepository.generateInviteLink(groupID)
+        return intent
+    }
+
+    @Test
+    fun `Clicking accept on an invite adds the current user to the group`() = runTest {
+        // UserGroup("2", "JDR", "Florian", setOf("Louis", "Florian", "Léo", "Val"))
+        (authRepository as MockAuthRepository).logIn(joseph)
+        groupRepository.setUserID(joseph.id)
+        val intent = groupInviteIntent("2")
+        val scenario = ActivityScenario.launch<GroupInviteActivity>(intent)
+        scenario.use {
+            onView(withId(R.id.group_invite_accept))
+                .perform(click())
+            assertThat(
+                "Group contains invited user",
+                groupRepository.fetch("2")?.members,
+                hasItem(joseph.id)
+            )
+        }
+    }
+
+    @Test
+    fun `Clicking deny on an invite does not add the current user to the group`() = runTest {
+        // UserGroup("2", "JDR", "Florian", setOf("Louis", "Florian", "Léo", "Val"))
+        (authRepository as MockAuthRepository).logIn(joseph)
+        groupRepository.setUserID(joseph.id)
+        val intent = groupInviteIntent("2")
+        val scenario = ActivityScenario.launch<GroupInviteActivity>(intent)
+        scenario.use {
+            onView(withId(R.id.group_invite_deny))
+                .perform(click())
+            assertThat(
+                "Group contains invited user",
+                groupRepository.fetch("2")?.members,
+                not(hasItem(joseph.id))
+            )
+        }
+    }
+
+    @Test
+    fun `Launching the activity for a group that the user has already joined shows the right message`() =
+        runTest {
+            // UserGroup("0", "SDP", "Joseph", setOf("Joseph", "Louis", "Florian", "Lenny", "Léo", "Val"))
+            (authRepository as MockAuthRepository).logIn(joseph)
+            groupRepository.setUserID(joseph.id)
+            val intent = groupInviteIntent("0")
+            val scenario = ActivityScenario.launch<GroupInviteActivity>(intent)
+            scenario.use {
+                val resources = InstrumentationRegistry.getInstrumentation().targetContext.resources
+                val message =
+                    resources.getString(R.string.group_invite_message_already_member_of_this_group)
+                onView(withId(R.id.group_invite_message))
+                    .check(matches(withText(message)))
+            }
+        }
+
+    @Test
+    fun `Launching the activity for a group ID that does not exist shows the right message`() =
+        runTest {
+            (authRepository as MockAuthRepository).logIn(joseph)
+            groupRepository.setUserID(joseph.id)
+            val deepLink = Uri.Builder()
+                .scheme("https")
+                .authority("multimatum.page.link")
+                .appendQueryParameter("id", "1234")
+                .build()
+            val inviteLink = Uri.Builder()
+                .scheme("https")
+                .authority("multimatum.page.link")
+                .appendQueryParameter("sd", "Click this link to accept the invite")
+                .appendQueryParameter("st", "Join non existing group")
+                .appendQueryParameter("apn", "com.github.multimatum_team.multimatum")
+                .appendQueryParameter("link", deepLink.toString())
+                .build()
+            val intent =
+                Intent(ApplicationProvider.getApplicationContext(), GroupInviteActivity::class.java)
+            intent.action = Intent.ACTION_VIEW
+            intent.data = inviteLink
+            val scenario = ActivityScenario.launch<GroupInviteActivity>(intent)
+            scenario.use {
+                val resources = InstrumentationRegistry.getInstrumentation().targetContext.resources
+                val message = resources.getString(R.string.group_invite_message_invalid)
+                onView(withId(R.id.group_invite_message))
+                    .check(matches(withText(message)))
+            }
+        }
+
+    @Test
+    fun `Launching the activity while being logged-in anonymously show the right message`() =
+        runTest {
+            val user = authRepository.signOut()
+            groupRepository.setUserID(user.id)
+            val intent = groupInviteIntent("0")
+            val scenario = ActivityScenario.launch<GroupInviteActivity>(intent)
+            scenario.use {
+                val resources = InstrumentationRegistry.getInstrumentation().targetContext.resources
+                val message = resources.getString(R.string.group_invite_message_must_be_signed_in)
+                onView(withId(R.id.group_invite_message))
+                    .check(matches(withText(message)))
+            }
+        }
+
+    @Module
+    @InstallIn(SingletonComponent::class)
+    object TestClockModule {
+        @Provides
+        fun provideClockService(): ClockService =
+            MockClockService(LocalDateTime.of(2022, 3, 12, 0, 0))
+    }
+
+    @Module
+    @InstallIn(SingletonComponent::class)
+    object TestDynamicLinksModule {
+        @Singleton
+        @Provides
+        fun providesFirebaseDynamicLinks(): FirebaseDynamicLinks =
+            mockFirebaseDynamicLinks()
+    }
+
+    @Module
+    @InstallIn(SingletonComponent::class)
+    object TestRepositoryModule {
+        @Singleton
+        @Provides
+        fun provideDeadlineRepository(): DeadlineRepository =
+            MockDeadlineRepository(listOf())
+
+        @Singleton
+        @Provides
+        fun provideGroupRepository(): GroupRepository =
+            MockGroupRepository(
+                listOf(
+                    UserGroup(
+                        "0",
+                        "SDP",
+                        "Joseph",
+                        setOf("Joseph", "Louis", "Florian", "Lenny", "Léo", "Val")
+                    ),
+                    UserGroup(
+                        "1",
+                        "MIT",
+                        "Louis",
+                        setOf("Joseph", "Louis", "Florian", "Lenny", "Léo", "Val")
+                    ),
+                    UserGroup(
+                        "2",
+                        "JDR",
+                        "Florian",
+                        setOf("Louis", "Florian", "Léo", "Val")
+                    ),
+                    UserGroup(
+                        "3",
+                        "Quantic",
+                        "Léo",
+                        setOf("Joseph", "Louis", "Florian", "Léo", "Val")
+                    ),
+                )
+            )
+
+        @Singleton
+        @Provides
+        fun provideAuthRepository(): AuthRepository =
+            MockAuthRepository()
+
+        @Singleton
+        @Provides
+        fun provideUserRepository(): UserRepository =
+            MockUserRepository(
+                listOf(
+                    UserInfo(id = "Joseph", name = "Joseph"),
+                    UserInfo(id = "Louis", name = "Louis"),
+                    UserInfo(id = "Florian", name = "Florian"),
+                    UserInfo(id = "Lenny", name = "Lenny"),
+                    UserInfo(id = "Léo", name = "Léo"),
+                    UserInfo(id = "Val", name = "Val"),
+                )
+            )
+
+        @Singleton
+        @Provides
+        fun providePdfRepository(): PdfRepository =
+            MockPdfRepository()
+    }
+}

--- a/app/src/test/java/com/github/multimatum_team/multimatum/util/MockFirebaseDynamicLinks.kt
+++ b/app/src/test/java/com/github/multimatum_team/multimatum/util/MockFirebaseDynamicLinks.kt
@@ -1,0 +1,33 @@
+package com.github.multimatum_team.multimatum.util
+
+import android.content.Intent
+import com.google.android.gms.tasks.Tasks
+import com.google.firebase.dynamiclinks.FirebaseDynamicLinks
+import com.google.firebase.dynamiclinks.PendingDynamicLinkData
+import com.google.firebase.dynamiclinks.internal.DynamicLinkData
+import org.mockito.Mockito
+import org.mockito.Mockito.`when`
+import org.mockito.kotlin.any
+
+fun mockFirebaseDynamicLinks(): FirebaseDynamicLinks {
+    val dynamicLinks = Mockito.mock(FirebaseDynamicLinks::class.java)
+    `when`(dynamicLinks.getDynamicLink(any<Intent>())).then {
+        val intent = it.getArgument<Intent>(0)
+        var dynamicLink: String? = null
+        var deepLink: String? = null
+        if (intent.data != null) {
+            dynamicLink = intent.data.toString()
+            deepLink = intent.data!!.getQueryParameter("link")!!
+        }
+        val dynamicLinkData = DynamicLinkData(
+            dynamicLink,
+            deepLink,
+            0,
+            0,
+            null,
+            null
+        )
+        Tasks.forResult(PendingDynamicLinkData(dynamicLinkData))
+    }
+    return dynamicLinks
+}

--- a/app/src/test/java/com/github/multimatum_team/multimatum/util/MockGroupRepository.kt
+++ b/app/src/test/java/com/github/multimatum_team/multimatum/util/MockGroupRepository.kt
@@ -1,5 +1,6 @@
 package com.github.multimatum_team.multimatum.util
 
+import android.net.Uri
 import com.github.multimatum_team.multimatum.model.GroupID
 import com.github.multimatum_team.multimatum.model.UserGroup
 import com.github.multimatum_team.multimatum.model.UserID
@@ -16,11 +17,7 @@ import com.github.multimatum_team.multimatum.repository.GroupRepository
 class MockGroupRepository(initialContents: List<UserGroup>) : GroupRepository() {
     private var counter: Int = 0
 
-    private val groupsPerUser: MutableMap<UserID, MutableMap<GroupID, UserGroup>> =
-        mutableMapOf()
-
-    private val groups: MutableMap<GroupID, UserGroup>
-        get() = groupsPerUser.getOrPut(_userID) { mutableMapOf() }
+    private val groups: MutableMap<GroupID, UserGroup> = mutableMapOf()
 
     private val updateListeners: MutableMap<UserID, MutableList<(Map<GroupID, UserGroup>) -> Unit>> =
         mutableMapOf()
@@ -29,11 +26,7 @@ class MockGroupRepository(initialContents: List<UserGroup>) : GroupRepository() 
         for (group in initialContents) {
             val newID = counter.toString()
             counter++
-            for (memberID in group.members) {
-                groupsPerUser
-                    .getOrPut(memberID) { mutableMapOf() }
-                    .put(newID, group.copy(id = newID))
-            }
+            groups[newID] = group.copy(id = newID)
         }
         setUserID("0")
     }
@@ -41,7 +34,11 @@ class MockGroupRepository(initialContents: List<UserGroup>) : GroupRepository() 
     private fun notifyUpdateListeners() =
         updateListeners[_userID]?.forEach { it(groups) }
 
-    override suspend fun fetchAll(): Map<GroupID, UserGroup> = groups
+    override suspend fun fetch(id: GroupID): UserGroup? =
+        groups[id]
+
+    override suspend fun fetchAll(): Map<GroupID, UserGroup> =
+        groups.filterValues { group -> group.members.contains(_userID) }
 
     override suspend fun create(name: String): GroupID {
         val id = counter.toString()
@@ -62,23 +59,36 @@ class MockGroupRepository(initialContents: List<UserGroup>) : GroupRepository() 
         notifyUpdateListeners()
     }
 
-    override suspend fun invite(id: GroupID, email: String) {
-        throw UnsupportedOperationException("group invites are not supported")
+    override suspend fun generateInviteLink(id: GroupID): Uri {
+        val group = fetch(id)!!
+        val inviteLink = Uri.Builder()
+            .scheme("https")
+            .authority("multimatum.page.link")
+            .appendQueryParameter("id", group.id)
+            .build()
+        return Uri.Builder()
+            .scheme("https")
+            .authority("multimatum.page.link")
+            .appendQueryParameter("sd", "Click this link to accept the invite")
+            .appendQueryParameter("st", "Join group ${group.name}")
+            .appendQueryParameter("apn", "com.github.multimatum_team.multimatum")
+            .appendQueryParameter("link", inviteLink.toString())
+            .build()
+    }
+
+    override suspend fun addMember(groupID: GroupID, memberID: UserID) {
+        val group = groups[groupID]!!
+        val newMembers = group.members.toMutableList()
+        newMembers.add(memberID)
+        groups[groupID] = group.copy(members = newMembers.toSet())
+        notifyUpdateListeners()
     }
 
     override suspend fun removeMember(groupID: GroupID, memberID: UserID) {
-        var group = groups[groupID]!!
-        val newMembers = group.members.toMutableSet()
+        val group = groups[groupID]!!
+        val newMembers = group.members.toMutableList()
         newMembers.remove(memberID)
-        println("$_userID, $group, $newMembers")
-        group = group.copy(members = newMembers)
-        groupsPerUser[memberID]?.remove(groupID)
-        for (groupMap in groupsPerUser.values) {
-            if (groupMap.containsKey(groupID)) {
-                groupMap[groupID] = group
-            }
-        }
-        println("removed $memberID from $groupID: $newMembers")
+        groups[groupID] = group.copy(members = newMembers.toSet())
         notifyUpdateListeners()
     }
 


### PR DESCRIPTION
This PR implements group invites using Firebase dynamic links. The way it works is that, when clicking on the invite button in the group details activity, a https link is generated and stored into your clipboard, so that you can send it to people you want to invite. When people click on this link on their phone, a new activity called `GroupInviteActivity` will show up and prompt the user who can then chose to accept the invitation (upon which they will be added to the group and redirected to the main activity), or deny it (upon which the application is closed).

To implement this feature, I had to change the semantics of `GroupRepository.fetch` which before was expected to fetch a group that the currently logged-in user has joined. Now, it can fetch any group (which further complicates firebase protection rules)
Therefore, the group viewmodel includes a new `fetchNewGroup` method which allows retrieving any group from the repository, and not just a group which we belong to (which is what `getGroup` does. 