### PR TITLE
Fix bug in `DeadlineDetailsActivity` causing the app to crash when clicking on a group owned deadline

### DIFF
--- a/app/src/main/java/com/github/multimatum_team/multimatum/activity/DeadlineDetailsActivity.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/activity/DeadlineDetailsActivity.kt
@@ -321,8 +321,6 @@ class DeadlineDetailsActivity : AppCompatActivity() {
             descriptionView.text = SpannableStringBuilder(description)
             doneButton.isChecked = (state == DeadlineState.DONE)
             updateDetail()
-            findViewById<TextView>(R.id.deadline_details_activity_group).text =
-                getGroupTextAndSetModifyButton(group)
 
             // Set the View to be unmodifiable at the start and remove displacement of the texts
             normalSetup()


### PR DESCRIPTION
See linked issue for a more detailed description of the bug.

Closes #266 