### PR TITLE
Rename tests for consistency

### DIFF
--- a/app/src/test/java/com/github/multimatum_team/multimatum/CalendarActivityTest.kt
+++ b/app/src/test/java/com/github/multimatum_team/multimatum/CalendarActivityTest.kt
@@ -51,13 +51,13 @@ class CalendarActivityTest {
     }
 
     @Test
-    fun textInputFieldCanBeClicked() {
+    fun `text input field should be clickable`() {
         Espresso.onView(ViewMatchers.withId(R.id.textInputEditCalendar))
             .check(ViewAssertions.matches(ViewMatchers.isClickable()))
     }
 
     @Test
-    fun textInputScreenReleasedAfterAddingDeadlineWithButton() {
+    fun `text input screen should be released after adding deadline with button`() {
         Espresso.onView(ViewMatchers.withId(R.id.textInputEditCalendar))
             .perform(click())
             .perform(typeText("deadlineTestCase"))
@@ -68,7 +68,7 @@ class CalendarActivityTest {
     }
 
     @Test
-    fun textInputScreenReleasedAfterAddingDeadlineWithEnterKey() {
+    fun `text input screen should be released after adding deadline with enter key`() {
         Espresso.onView(ViewMatchers.withId(R.id.textInputEditCalendar))
             .perform(click())
             .perform(typeText("deadlineTestCase2"))
@@ -78,7 +78,7 @@ class CalendarActivityTest {
     }
 
     @Test
-    fun textInputScreenReleasedAfterAddingDeadlineWithDoneOnSoftKeyboard() {
+    fun `text input screen should be released after adding deadline with done on SoftKeyboard`() {
         Espresso.onView(ViewMatchers.withId(R.id.textInputEditCalendar))
             .perform(click())
             .perform(typeText("deadlineTestCase3"))

--- a/app/src/test/java/com/github/multimatum_team/multimatum/DateTimeExtractorTest.kt
+++ b/app/src/test/java/com/github/multimatum_team/multimatum/DateTimeExtractorTest.kt
@@ -37,7 +37,7 @@ class DateTimeExtractorTest {
     }
 
     @Test
-    fun `18h_is_parsed_correctly`() {
+    fun `18h is parsed correctly`() {
         val str = "Geography 18h"
         val expText = "Geography"
         val actualRes = DEFAULT_DATE_TIME_EXTRACTOR.parse(str)
@@ -45,7 +45,7 @@ class DateTimeExtractorTest {
     }
 
     @Test
-    fun `10h00_is_parsed_correctly`() {
+    fun `10h00 is parsed correctly`() {
         val str = "Aqua-pony at 10:00"
         val expText = "Aqua-pony"
         val actualRes = DEFAULT_DATE_TIME_EXTRACTOR.parse(str)
@@ -53,7 +53,7 @@ class DateTimeExtractorTest {
     }
 
     @Test
-    fun am_time_is_parsed_correctly() {
+    fun `am time is parsed correctly`() {
         val str = "Chemistry 2am (report)"
         val expText = "Chemistry (report)"
         val actualRes = DEFAULT_DATE_TIME_EXTRACTOR.parse(str)
@@ -61,7 +61,7 @@ class DateTimeExtractorTest {
     }
 
     @Test
-    fun pm_time_is_parsed_correctly() {
+    fun `pm time is parsed correctly`() {
         val str = "History dissertation 4pm"
         val expText = "History dissertation"
         val actualRes = DEFAULT_DATE_TIME_EXTRACTOR.parse(str)
@@ -69,7 +69,7 @@ class DateTimeExtractorTest {
     }
 
     @Test
-    fun second_time_is_ignored() {
+    fun `second time is ignored`() {
         val str = "History dissertation 4pm 5pm"
         val expText = "History dissertation 5pm"
         val actualRes = DEFAULT_DATE_TIME_EXTRACTOR.parse(str)
@@ -77,7 +77,7 @@ class DateTimeExtractorTest {
     }
 
     @Test
-    fun complete_date_is_parsed_correctly_in_d_m_y_format() {
+    fun `complete date is parsed correctly in d-m-y format`() {
         val str = "Entree en bourse de Multimatum&co 1.08.2022"
         val expText = "Entree en bourse de Multimatum&co"
         val actualRes = DEFAULT_DATE_TIME_EXTRACTOR.parse(str)
@@ -85,7 +85,7 @@ class DateTimeExtractorTest {
     }
 
     @Test
-    fun complete_date_is_parsed_correctly_in_y_m_d_format() {
+    fun `complete date is parsed correctly in y-m-d format`() {
         val str = "Entree en bourse de Multimatum&co 2022.8.1"
         val expText = "Entree en bourse de Multimatum&co"
         val actualRes = DEFAULT_DATE_TIME_EXTRACTOR.parse(str)
@@ -93,7 +93,7 @@ class DateTimeExtractorTest {
     }
 
     @Test
-    fun invalid_date_is_ignored() {
+    fun `invalid date is ignored`() {
         // should reject 29.02.2021 (does not exist), but take 5.12.2021 (valid)
         val str = "New version release 29.2.2021.12.5"
         val expText = "New version release 29.2."
@@ -102,7 +102,7 @@ class DateTimeExtractorTest {
     }
 
     @Test
-    fun valid_february29_should_be_parsed_correctly() {
+    fun `valid february 29 should be parsed correctly`() {
         val str = "Declaration d'impots 29.2.2024"
         val expText = "Declaration d'impots"
         val actualRes = DEFAULT_DATE_TIME_EXTRACTOR.parse(str)
@@ -110,7 +110,7 @@ class DateTimeExtractorTest {
     }
 
     @Test
-    fun date_and_time_in_same_string_should_be_parsed_correctly() {
+    fun `date and time in same string should be parsed correctly`() {
         val str = "Rendu devoir 23.8.2020 14:30"
         val expText = "Rendu devoir"
         val actualRes = DEFAULT_DATE_TIME_EXTRACTOR.parse(str)
@@ -124,7 +124,7 @@ class DateTimeExtractorTest {
     }
 
     @Test
-    fun day_of_week_should_be_parsed_correctly() {
+    fun `day of week should be parsed correctly`() {
         val str = "SDP meeting friday"
         val expText = "SDP meeting"
         val currentDate = LocalDate.of(2022, Month.APRIL, 30)
@@ -135,7 +135,7 @@ class DateTimeExtractorTest {
     }
 
     @Test
-    fun day_of_week_with_on_should_be_parsed_correctly() {
+    fun `day of week with on should be parsed correctly`() {
         val str = "SDP meeting on friday"
         val expText = "SDP meeting"
         val currentDate = LocalDate.of(2022, Month.APRIL, 30)
@@ -146,7 +146,7 @@ class DateTimeExtractorTest {
     }
 
     @Test
-    fun month_given_by_3_letters_name_is_parsed_correctly() {
+    fun `month given by 3 letters name is parsed correctly`() {
         val str = "Devoir a rendre 15 oct 2019"
         val expText = "Devoir a rendre"
         val actualRes = DEFAULT_DATE_TIME_EXTRACTOR.parse(str)
@@ -156,7 +156,7 @@ class DateTimeExtractorTest {
     }
 
     @Test
-    fun month_given_by_full_name_is_parsed_correctly() {
+    fun `month given by full name is parsed correctly`() {
         val str = "Something to hand-in 23 jan 2018 in math"
         val expText = "Something to hand-in in math"
         val actualRes = DEFAULT_DATE_TIME_EXTRACTOR.parse(str)
@@ -166,7 +166,7 @@ class DateTimeExtractorTest {
     }
 
     @Test
-    fun thursday_20_is_parsed_correctly() {
+    fun `thursday 20 is parsed correctly`() {
         val str = "Physics experiment report thursday 20"
         val expText = "Physics experiment report"
         val currentDate = LocalDate.of(2022, Month.JANUARY, 12)
@@ -175,7 +175,7 @@ class DateTimeExtractorTest {
     }
 
     @Test
-    fun friday_20_is_rejected_when_the_20th_is_not_a_friday() {
+    fun `friday 20 is rejected when the 20th is not a friday`() {
         /* what happens here is that the extractor tries
          * to match "friday 20", notices that the 20th is not
          * a friday and falls back to parsing only "friday" */
@@ -187,7 +187,7 @@ class DateTimeExtractorTest {
     }
 
     @Test
-    fun midday_is_parsed_correctly() {
+    fun `midday is parsed correctly`() {
         val str = "Lunch at noon"
         val expText = "Lunch"
         val actualRes = DEFAULT_DATE_TIME_EXTRACTOR.parse(str)
@@ -195,7 +195,7 @@ class DateTimeExtractorTest {
     }
 
     @Test
-    fun midnight_is_parsed_correctly() {
+    fun `midnight is parsed correctly`() {
         val str = "Due work at midnight"
         val expText = "Due work"
         val actualRes = DEFAULT_DATE_TIME_EXTRACTOR.parse(str)
@@ -203,7 +203,7 @@ class DateTimeExtractorTest {
     }
 
     @Test
-    fun tomorrow_is_parsed_correctly() {
+    fun `tomorrow is parsed correctly`() {
         val str = "Due homework tomorrow"
         val expText = "Due homework"
         val currentDate = LocalDate.of(2020, 4, 4)
@@ -213,7 +213,7 @@ class DateTimeExtractorTest {
     }
 
     @Test
-    fun may_3rd_is_parsed_correctly() {
+    fun `may 3rd is parsed correctly`() {
         val str = "Report May 3rd"
         val expText = "Report"
         val currDate = LocalDate.of(2021, Month.MARCH, 17)
@@ -223,7 +223,7 @@ class DateTimeExtractorTest {
     }
 
     @Test
-    fun `may-3_is_parsed_correctly`() {
+    fun `may-3 is parsed correctly`() {
         val str = "Report May-3"
         val expText = "Report"
         val currDate = LocalDate.of(2021, Month.MARCH, 17)
@@ -233,7 +233,7 @@ class DateTimeExtractorTest {
     }
 
     @Test
-    fun `3dot12_is_parsed_correctly`() {
+    fun `3dot12 is parsed correctly`() {
         val str = "Something to submit 3.14"
         val expText = "Something to submit"
         val currDate = LocalDate.of(2021, Month.JANUARY, 10)
@@ -243,7 +243,7 @@ class DateTimeExtractorTest {
     }
 
     @Test
-    fun `12dot3_is_parsed_correctly`() {
+    fun `12dot3 is parsed correctly`() {
         val str = "Something to submit 14.3"
         val expText = "Something to submit"
         val currDate = LocalDate.of(2021, Month.JANUARY, 10)
@@ -253,7 +253,7 @@ class DateTimeExtractorTest {
     }
 
     @Test
-    fun `11h45am_is_parsed_correctly`() {
+    fun `11h45am is parsed correctly`() {
         val str = "Apero at 11h45am"
         val expText = "Apero"
         val expectedTime = LocalTime.of(11, 45)
@@ -261,7 +261,7 @@ class DateTimeExtractorTest {
     }
 
     @Test
-    fun `7h27pm_is_parsed_correctly`() {
+    fun `7h27pm is parsed correctly`() {
         val str = "Apero at 7h27pm"
         val expText = "Apero"
         val expectedTime = LocalTime.of(19, 27)
@@ -269,7 +269,7 @@ class DateTimeExtractorTest {
     }
 
     @Test
-    fun `2022_2_27_is_parsed_correctly`(){
+    fun `2022 2 27 is parsed correctly`() {
         val str = "ToDo 2022 2 27"
         val expText = "ToDo"
         val expectedDate = LocalDate.of(2022, Month.FEBRUARY, 27)

--- a/app/src/test/java/com/github/multimatum_team/multimatum/DeadlineNotificationTest.kt
+++ b/app/src/test/java/com/github/multimatum_team/multimatum/DeadlineNotificationTest.kt
@@ -65,7 +65,7 @@ class DeadlineNotificationTest {
      * Test if createNotification channel creates a notification channel with the right parameters
      */
     @Test
-    fun testCreateNotificationChannel() {
+    fun `createNotificationChannel should create a notification channel`() {
         val channel = NotificationChannel(
             "remindersChannel",
             "reminders channel",
@@ -80,7 +80,7 @@ class DeadlineNotificationTest {
     }
 
     @Test
-    fun testAddAndDeleteNotification() {
+    fun `adding and deleting notifications should result in the correct manager state`() {
         val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
         val shadowAlarmManager: ShadowAlarmManager = Shadows.shadowOf(alarmManager)
 
@@ -99,7 +99,7 @@ class DeadlineNotificationTest {
     }
 
     @Test
-    fun testUpdateAndListNotification() {
+    fun `updating and listing notifications should result in the correct manager state`() {
         val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
         val shadowAlarmManager: ShadowAlarmManager = Shadows.shadowOf(alarmManager)
         val id1 = "ADDED_DEADLINE_1"

--- a/app/src/test/java/com/github/multimatum_team/multimatum/MainActivityTest.kt
+++ b/app/src/test/java/com/github/multimatum_team/multimatum/MainActivityTest.kt
@@ -72,7 +72,7 @@ class MainActivityTest {
     }
 
     @Test
-    fun goToSetting() {
+    fun `clicking on the settings button should open the settings`() {
         onView(withId(R.id.main_open_settings_but)).perform(click())
         Intents.intended(
             allOf(
@@ -83,7 +83,7 @@ class MainActivityTest {
     }
 
     @Test
-    fun goToDeadlineDetails() {
+    fun `long click on deadline listview should open DeadlineDetailsActivity`() {
         onData(anything()).inAdapterView(withId(R.id.deadlineListView)).atPosition(0)
             .perform(longClick())
 
@@ -100,7 +100,7 @@ class MainActivityTest {
     }
 
     @Test
-    fun goToCalendar() {
+    fun `clicking on the calendar button should open the calendar`() {
         onView(withId(R.id.goToCalendarButton)).perform(click())
         Intents.intended(
             allOf(
@@ -111,7 +111,7 @@ class MainActivityTest {
     }
 
     @Test
-    fun goToAddDeadlineActivity() {
+    fun `clicking on add deadline button should add a deadline`() {
         onView(withId(R.id.main_go_to_add_deadline)).perform(click())
         Intents.intended(
             allOf(
@@ -122,7 +122,7 @@ class MainActivityTest {
     }
 
     @Test
-    fun buttonOpensQrCodeReader() {
+    fun `clicking on the QR code reader button should open the QR code reader`() {
         grantPermission()
         onView(withId(R.id.goToQrCodeReader)).perform(click())
         Intents.intended(
@@ -134,7 +134,7 @@ class MainActivityTest {
     }
 
     @Test
-    fun goToGroupsTest() {
+    fun `clicking on the group button should open GroupsActivity`() {
         onView(withId(R.id.groupButton)).check(matches(isDisplayed())).perform(click())
         Intents.intended(
             allOf(
@@ -145,14 +145,14 @@ class MainActivityTest {
     }
 
     @Test
-    fun buttonDoesNotOpenQrCodeReaderIfPermissionNotGranted() {
+    fun `button does not open QR code reader if permission not granted`() {
         onView(withId(R.id.goToQrCodeReader)).perform(click())
         denyPermission()
         onView(withId(R.id.goToQrCodeReader)).check(matches(isDisplayed()))
     }
 
     @Test
-    fun swipeDeadlineTwiceShouldDelete() {
+    fun `swipe deadline twice should delete it`() {
         onData(anything()).inAdapterView(withId(R.id.deadlineListView))
             .atPosition(0).perform(swipeRight())
         onData(anything()).inAdapterView(withId(R.id.deadlineListView))
@@ -161,7 +161,7 @@ class MainActivityTest {
     }
 
     @Test
-    fun swipeDeadlineOnceAndClickUndoShouldUndo() {
+    fun `swipe deadline once and click undo should undo`() {
         onData(anything()).inAdapterView(withId(R.id.deadlineListView)).atPosition(0)
             .perform(swipeLeft())
         onData(anything()).inAdapterView(withId(R.id.deadlineListView)).atPosition(0)

--- a/app/src/test/java/com/github/multimatum_team/multimatum/MainSettingsActivityTest.kt
+++ b/app/src/test/java/com/github/multimatum_team/multimatum/MainSettingsActivityTest.kt
@@ -75,8 +75,8 @@ class MainSettingsActivityTest {
     }
 
     @Test
-    fun disabling_notifications_on_button_disables_them_in_preferences() {
-        testScenario(
+    fun `disabling notifications on button disables them in preferences`() {
+        twoStatesButtonToSharedPreferencesTestScenario(
             initNotifEnabled = true, initDarkModeEnabled = false,
             clickedButtonId = R.id.main_settings_enable_notif_button,
             expectedFinalNotifEnabled = false, expectedFinalDarkModeEnabled = false
@@ -84,8 +84,8 @@ class MainSettingsActivityTest {
     }
 
     @Test
-    fun enabling_notifications_on_button_enables_them_in_preferences() {
-        testScenario(
+    fun `enabling notifications on button enables them in preferences`() {
+        twoStatesButtonToSharedPreferencesTestScenario(
             initNotifEnabled = false, initDarkModeEnabled = false,
             clickedButtonId = R.id.main_settings_enable_notif_button,
             expectedFinalNotifEnabled = true, expectedFinalDarkModeEnabled = false
@@ -93,7 +93,7 @@ class MainSettingsActivityTest {
     }
 
     @Test
-    fun launchProfileActivityIntent() = runTest {
+    fun `launch profile activity should produce intent`() = runTest {
         (authRepository as MockAuthRepository).signIn("John Doe", "john.doe@example.com")
         val scenario = ActivityScenario.launch(MainSettingsActivity::class.java)
         scenario.use {
@@ -104,8 +104,8 @@ class MainSettingsActivityTest {
     }
 
     @Test
-    fun disabling_dark_mode_on_button_disables_them_in_preferences() {
-        testScenario(
+    fun `disabling dark mode on button disables them in preferences`() {
+        twoStatesButtonToSharedPreferencesTestScenario(
             initNotifEnabled = true, initDarkModeEnabled = true,
             clickedButtonId = R.id.main_settings_dark_mode_button,
             expectedFinalNotifEnabled = true, expectedFinalDarkModeEnabled = false
@@ -113,8 +113,8 @@ class MainSettingsActivityTest {
     }
 
     @Test
-    fun enabling_dark_mode_on_button_enables_them_in_preferences() {
-        testScenario(
+    fun `enabling dark mode on button enables them in preferences`() {
+        twoStatesButtonToSharedPreferencesTestScenario(
             initNotifEnabled = false, initDarkModeEnabled = false,
             clickedButtonId = R.id.main_settings_dark_mode_button,
             expectedFinalNotifEnabled = false, expectedFinalDarkModeEnabled = true
@@ -123,7 +123,7 @@ class MainSettingsActivityTest {
 
     // inspired from https://www.androidbugfix.com/2021/09/androidx-how-to-test-slider-in-ui-tests.html
     @Test
-    fun value_selected_on_slider_is_written_to_preferences() {
+    fun `value selected on slider is written to preferences`() {
         val mockEditor: SharedPreferences.Editor = mock()
         `when`(
             mockSharedPreferences.getBoolean(
@@ -177,7 +177,7 @@ class MainSettingsActivityTest {
     // and the expected final states of the buttons
     // The method checks that settings values are correctly written to SharedPreferences and
     // that the buttons are at the expected position at the end of the scenario
-    private fun testScenario(
+    private fun twoStatesButtonToSharedPreferencesTestScenario(
         initNotifEnabled: Boolean, initDarkModeEnabled: Boolean,
         clickedButtonId: Int,
         expectedFinalNotifEnabled: Boolean, expectedFinalDarkModeEnabled: Boolean

--- a/app/src/test/java/com/github/multimatum_team/multimatum/PDFUtilTest.kt
+++ b/app/src/test/java/com/github/multimatum_team/multimatum/PDFUtilTest.kt
@@ -12,14 +12,14 @@ import java.util.*
 @RunWith(AndroidJUnit4::class)
 class PDFUtilTest {
     @Test
-    fun testSelectPDF() {
+    fun `selecting a PDF should produce the correct intent`() {
         PDFUtil.selectPdfIntent {
             assertEquals(Intent.ACTION_GET_CONTENT, it.action)
         }
     }
 
     @Test
-    fun testStrRandom() {
+    fun `adding a random char to string should work correctly`() {
         val input = "someString"
         val out1 = PDFUtil.addRdmCharToStr(input, 16)
         val out2 = PDFUtil.addRdmCharToStr(input, 16)

--- a/app/src/test/java/com/github/multimatum_team/multimatum/QRGeneratorActivityTest.kt
+++ b/app/src/test/java/com/github/multimatum_team/multimatum/QRGeneratorActivityTest.kt
@@ -32,6 +32,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.time.LocalDateTime
+import java.time.Month
 
 
 /**
@@ -53,7 +54,7 @@ class QRGeneratorActivityTest {
     }
 
     @Test
-    fun goToQRTest() {
+    fun `clicking on return button should produce correct intent`() {
         Espresso.onView(ViewMatchers.withId(R.id.returnToMainFromQR)).perform(ViewActions.click())
         Intents.intended(
             Matchers.allOf(
@@ -64,10 +65,9 @@ class QRGeneratorActivityTest {
     }
 
     @Test
-    fun qRDisplayTest() {
+    fun `displayed QR code should be correct`() {
         val data = Deadline(
-            "Appeller Robert", DeadlineState.TODO, LocalDateTime.now()
-                .plusDays(1)
+            "Appeller Robert", DeadlineState.TODO, LocalDateTime.of(2020, Month.JUNE, 2, 14, 27)
         )
         val intent = Intent(
             ApplicationProvider.getApplicationContext(),

--- a/app/src/test/java/com/github/multimatum_team/multimatum/ReminderBroadcastReceiverTest.kt
+++ b/app/src/test/java/com/github/multimatum_team/multimatum/ReminderBroadcastReceiverTest.kt
@@ -56,7 +56,7 @@ class ReminderBroadcastReceiverTest {
      * Test if the broadCast receiver launch a notification when "onReceive" is called
      */
     @Test
-    fun testNotificationLaunchOnReceive() {
+    fun `calling onReceive should result in the correct manager state`() {
         Mockito.`when`(
             mockSharedPreferences.getBoolean(
                 eq(MainSettingsActivity.NOTIF_ENABLED_PREF_KEY),

--- a/app/src/test/java/com/github/multimatum_team/multimatum/TokensTest.kt
+++ b/app/src/test/java/com/github/multimatum_team/multimatum/TokensTest.kt
@@ -7,7 +7,7 @@ import org.junit.Test
 
 class TokensTest {
     @Test
-    fun string_is_tokenized_correctly() {
+    fun `string is tokenized correctly`() {
         val str = "abcd1234 !/xyz. 987"
         val exp = listOf(
             AlphabeticToken("abcd"),
@@ -24,7 +24,7 @@ class TokensTest {
     }
 
     @Test
-    fun deadline_title_including_date_and_time_is_tokenized_correctly() {
+    fun `deadline title including date and time is tokenized correctly`() {
         val title = "Aqua-poney monday 15 at 11am"
         val exp = listOf(
             AlphabeticToken("Aqua"),
@@ -44,7 +44,7 @@ class TokensTest {
     }
 
     @Test
-    fun numericToken_gives_correct_numeric_value() {
+    fun `numericToken gives correct numeric value`() {
         val inputsOutputs = listOf(
             "123" to 123,
             "0" to 0,
@@ -56,7 +56,7 @@ class TokensTest {
     }
 
     @Test
-    fun symbolToken_gives_correct_char_value() {
+    fun `symbolToken gives correct char value`() {
         val inputsOutputs = listOf(
             "!" to '!',
             "*" to '*',
@@ -68,14 +68,14 @@ class TokensTest {
     }
 
     @Test
-    fun numericToken_throws_on_non_numeric_input() {
+    fun `numericToken throws on non numeric input`() {
         assertThrows(IllegalArgumentException::class.java) {
             NumericToken("123a4")
         }
     }
 
     @Test
-    fun symbolToken_throws_on_input_with_length_different_of_1() {
+    fun `symbolToken throws on input with length different of 1`() {
         assertThrows(IllegalArgumentException::class.java) {
             SymbolToken("[!]")
         }

--- a/app/src/test/java/com/github/multimatum_team/multimatum/service/ProcrastinationDetectorServiceTest.kt
+++ b/app/src/test/java/com/github/multimatum_team/multimatum/service/ProcrastinationDetectorServiceTest.kt
@@ -72,7 +72,7 @@ class ProcrastinationDetectorServiceTest {
     }
 
     @Test
-    fun service_should_be_registered_as_listener_and_then_unregistered() {
+    fun `service should be registered as listener and then unregistered`() {
         val mockSensor: Sensor = mock()
         var wasRegistered = false
         var wasUnregistered = false
@@ -117,7 +117,7 @@ class ProcrastinationDetectorServiceTest {
     }
 
     @Test
-    fun toast_should_be_displayed_when_sensor_detected_major_change() {
+    fun `toast should be displayed when sensor detected major change`() {
         val mockSensor: Sensor = mock()
         val mockSensorEvent: SensorEvent = mock()
         `when`(mockSensorManager.getDefaultSensor(eq(ProcrastinationDetectorService.REF_SENSOR))).thenReturn(
@@ -139,7 +139,7 @@ class ProcrastinationDetectorServiceTest {
     }
 
     @Test
-    fun toast_should_be_displayed_when_sensor_detected_major_change_even_after_a_call_to_onAccuracyChanged() {
+    fun `toast should be displayed when sensor detected major change even after a call to onAccuracyChanged`() {
         val mockSensor: Sensor = mock()
         val mockSensorEvent: SensorEvent = mock()
         `when`(mockSensorManager.getDefaultSensor(eq(ProcrastinationDetectorService.REF_SENSOR))).thenReturn(
@@ -162,7 +162,7 @@ class ProcrastinationDetectorServiceTest {
     }
 
     @Test
-    fun toast_should_not_be_displayed_when_sensor_detected_tiny_change() {
+    fun `toast should not be displayed when sensor detected tiny change`() {
         val mockSensor: Sensor = mock()
         val mockSensorEvent: SensorEvent = mock()
         `when`(mockSensorManager.getDefaultSensor(eq(ProcrastinationDetectorService.REF_SENSOR))).thenReturn(
@@ -184,7 +184,7 @@ class ProcrastinationDetectorServiceTest {
     }
 
     @Test
-    fun on_bind_should_return_a_binder_that_is_able_to_provide_the_bound_service() {
+    fun `on bind should return a binder that is able to provide the bound service`() {
         val controller = createTestServiceController()
         val service = controller.get()
         val dummyIntent = Intent(applicationContext, javaClass)
@@ -199,7 +199,7 @@ class ProcrastinationDetectorServiceTest {
     }
 
     @Test
-    fun onStartCommand_throws_when_sensor_not_found() {
+    fun `onStartCommand throws when sensor not found`() {
         `when`(mockSensorManager.getDefaultSensor(any())).thenReturn(null)
         var controller: ServiceController<ProcrastinationDetectorService>? = null
         assertThrows(IllegalStateException::class.java) {
@@ -210,7 +210,7 @@ class ProcrastinationDetectorServiceTest {
     }
 
     @Test
-    fun onStartCommand_throws_when_invalid_action() {
+    fun `onStartCommand throws when invalid action`() {
         `when`(mockSensorManager.getDefaultSensor(any())).thenReturn(mock())
         val intent = Intent(applicationContext, ProcrastinationDetectorService::class.java)
         intent.action = "not_a_valid_action"
@@ -226,7 +226,7 @@ class ProcrastinationDetectorServiceTest {
     }
 
     @Test
-    fun toast_should_not_be_displayed_when_another_toast_has_been_displayed_too_recently() {
+    fun `toast should not be displayed when another toast has been displayed too recently`() {
         val mockSensor: Sensor = mock()
         val mockSensorEvent: SensorEvent = mock()
         `when`(mockSensorManager.getDefaultSensor(eq(ProcrastinationDetectorService.REF_SENSOR))).thenReturn(
@@ -255,7 +255,7 @@ class ProcrastinationDetectorServiceTest {
     }
 
     @Test
-    fun onSensorChanged_throws_on_invalid_array_in_event() {
+    fun `onSensorChanged throws on invalid array in event`() {
         val mockSensor: Sensor = mock()
         `when`(mockSensorManager.getDefaultSensor(eq(ProcrastinationDetectorService.REF_SENSOR))).thenReturn(
             mockSensor
@@ -277,7 +277,7 @@ class ProcrastinationDetectorServiceTest {
     }
 
     @Test
-    fun launch_should_call_startForegroundService_with_start_action() {
+    fun `launch should call startForegroundService with start action`() {
         val mockCaller: Context = mock()
         var actualIntent: Intent? = null
         `when`(mockCaller.startForegroundService(any())).then {
@@ -301,7 +301,12 @@ class ProcrastinationDetectorServiceTest {
         controller.destroy()
     }
 
-    private data class EventToSimulate(val x: Float, val y: Float, val z: Float, val timestamp: Long)
+    private data class EventToSimulate(
+        val x: Float,
+        val y: Float,
+        val z: Float,
+        val timestamp: Long
+    )
 
     /**
      * WARNING this method does not perform any assertion


### PR DESCRIPTION
Following the advice from #255, I renamed the tests so that their identifiers are more consistent. I used the plain text notation (the one with spaces and "\`") for the `test` folder and the camelCase notation for the `androidTest` folder (because these tests do not support the other notation).

Close #271