### PR TITLE
Test/display location activity

### DIFF
--- a/app/src/main/java/com/github/multimatum_team/multimatum/DependenciesProvider.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/DependenciesProvider.kt
@@ -6,7 +6,6 @@ import android.content.Context.MODE_PRIVATE
 import android.content.Context.SENSOR_SERVICE
 import android.content.SharedPreferences
 import android.hardware.SensorManager
-import androidx.lifecycle.ViewModel
 import com.budiyev.android.codescanner.CodeScanner
 import com.budiyev.android.codescanner.CodeScannerView
 import com.github.multimatum_team.multimatum.repository.*
@@ -18,6 +17,7 @@ import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.dynamiclinks.FirebaseDynamicLinks
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.storage.FirebaseStorage
+import com.mapbox.maps.MapView
 import dagger.Binds
 import dagger.Module
 import dagger.Provides
@@ -151,5 +151,23 @@ object GroupsActivityModule {
     @Provides
     fun provideGroupViewModelProducer(): GroupViewModelProducer =
         GroupViewModelProducer { normalViewModel -> normalViewModel }
+
+}
+
+data class MapViewProducer(val produce: (() -> MapView) -> MapView)
+
+data class ViewActionPerformer(val performViewAction: (() -> Unit) -> Unit)
+
+@Module
+@InstallIn(SingletonComponent::class)
+object DisplayLocationActivityModule {
+
+    @Provides
+    fun provideMapViewProducer(): MapViewProducer =
+        MapViewProducer { defaultMapViewCreator -> defaultMapViewCreator() }
+
+    @Provides
+    fun provideViewActionPerformer(): ViewActionPerformer =
+        ViewActionPerformer { viewAction -> viewAction() }
 
 }

--- a/app/src/main/java/com/github/multimatum_team/multimatum/DependenciesProvider.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/DependenciesProvider.kt
@@ -154,8 +154,18 @@ object GroupsActivityModule {
 
 }
 
+/**
+ * @param produce Given a function returning a MapView,
+ * returns a MapView, potentially using the given function
+ */
 data class MapViewProducer(val produce: (() -> MapView) -> MapView)
 
+/**
+ * Intended to be used only on actions related to the view
+ *
+ * @param performViewAction Given a callable, executes some action,
+ * potentially using the callable
+ */
 data class ViewActionPerformer(val performViewAction: (() -> Unit) -> Unit)
 
 @Module

--- a/app/src/main/java/com/github/multimatum_team/multimatum/activity/DisplayLocationActivity.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/activity/DisplayLocationActivity.kt
@@ -9,6 +9,8 @@ import android.os.Bundle
 import androidx.annotation.DrawableRes
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.content.res.AppCompatResources
+import com.github.multimatum_team.multimatum.ViewActionPerformer
+import com.github.multimatum_team.multimatum.MapViewProducer
 import com.github.multimatum_team.multimatum.R
 import com.mapbox.geojson.Point
 import com.mapbox.maps.CameraOptions
@@ -17,8 +19,17 @@ import com.mapbox.maps.Style
 import com.mapbox.maps.plugin.annotation.annotations
 import com.mapbox.maps.plugin.annotation.generated.PointAnnotationOptions
 import com.mapbox.maps.plugin.annotation.generated.createPointAnnotationManager
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
+@AndroidEntryPoint
 class DisplayLocationActivity : AppCompatActivity() {
+
+    @Inject
+    lateinit var mapViewProducer: MapViewProducer
+
+    @Inject
+    lateinit var viewActionPerformer: ViewActionPerformer
 
     private var mapView: MapView? = null
     private var latitude: Double = 0.0
@@ -27,14 +38,14 @@ class DisplayLocationActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_display_location)
+        viewActionPerformer.performViewAction { setContentView(R.layout.activity_display_location) }
 
         // Initializing the map
         initializeMapView()
     }
 
     private fun initializeMapView() {
-        mapView = findViewById(R.id.mapView)
+        mapView = mapViewProducer.produce { findViewById(R.id.mapView) }
         mapView?.getMapboxMap()?.loadStyleUri(
             Style.MAPBOX_STREETS
         ) { addAnnotationToMap() }

--- a/app/src/test/java/com/github/multimatum_team/multimatum/DisplayLocationActivityTest.kt
+++ b/app/src/test/java/com/github/multimatum_team/multimatum/DisplayLocationActivityTest.kt
@@ -1,0 +1,123 @@
+package com.github.multimatum_team.multimatum
+
+import android.content.Context
+import android.content.Intent
+import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.espresso.intent.Intents
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.multimatum_team.multimatum.activity.DisplayLocationActivity
+import com.mapbox.maps.CameraOptions
+import com.mapbox.maps.MapView
+import com.mapbox.maps.MapboxMap
+import com.mapbox.maps.Style
+import com.mapbox.maps.plugin.Plugin
+import com.mapbox.maps.plugin.annotation.AnnotationPlugin
+import com.mapbox.maps.plugin.annotation.generated.PointAnnotation
+import com.mapbox.maps.plugin.annotation.generated.PointAnnotationManager
+import com.mapbox.maps.plugin.annotation.generated.PointAnnotationOptions
+import com.mapbox.maps.plugin.annotation.generated.createPointAnnotationManager
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import dagger.hilt.android.testing.UninstallModules
+import dagger.hilt.components.SingletonComponent
+import org.junit.After
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers.anyString
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import javax.inject.Singleton
+
+@UninstallModules(DisplayLocationActivityModule::class)
+@HiltAndroidTest
+@RunWith(AndroidJUnit4::class)
+class DisplayLocationActivityTest {
+
+    @get:Rule
+    var hiltRule = HiltAndroidRule(this)
+
+    @Before
+    fun init() {
+        Intents.init()
+        hiltRule.inject()
+    }
+
+    @After
+    fun release() {
+        Intents.release()
+    }
+
+    @Test
+    fun `initializeMapView should initialize the mapView correctly`() {
+
+        val mockMapBoxMap: MapboxMap = mock()
+        val mockAnnotationsPlugin: AnnotationPlugin = mock()
+        val mockPointAnnotationManager: PointAnnotationManager = mock()
+
+        var cameraOptions: CameraOptions? = null
+        var pointAnnotationManagerCreated = false
+
+        whenever(mockMapView.getMapboxMap()).thenReturn(mockMapBoxMap)
+        whenever(mockMapBoxMap.loadStyleUri(anyString(), any<Style.OnStyleLoaded>())).then {
+            val onStyleLoaded: Style.OnStyleLoaded = it.getArgument(1)
+            onStyleLoaded.onStyleLoaded(mock())
+        }
+        whenever(mockMapBoxMap.setCamera(any<CameraOptions>())).then {
+            cameraOptions = it.getArgument(0)
+            null
+        }
+        // mocking getPlugin instead of annotations because it is a delegate property (and calls getPlugin)
+        whenever(mockMapView.getPlugin<AnnotationPlugin>(Plugin.MAPBOX_ANNOTATION_PLUGIN_ID)).thenReturn(mockAnnotationsPlugin)
+        whenever(mockAnnotationsPlugin.createPointAnnotationManager()).thenReturn(
+            mockPointAnnotationManager
+        )
+        whenever(mockPointAnnotationManager.create(any<PointAnnotationOptions>())).then {
+            pointAnnotationManagerCreated = true
+            mock<PointAnnotation>()
+        }
+
+        val applicationContext = ApplicationProvider.getApplicationContext<Context>()
+        val intent = Intent(applicationContext, DisplayLocationActivity::class.java)
+        val activityScenario: ActivityScenario<DisplayLocationActivity> =
+            ActivityScenario.launch(intent)
+
+        activityScenario.use {
+
+        }
+
+        assertNotNull(cameraOptions)
+        assertEquals(14.0, cameraOptions!!.zoom)
+        assertTrue(pointAnnotationManagerCreated)
+
+    }
+
+    companion object {
+        private val mockMapView: MapView = mock()
+    }
+
+    @Module
+    @InstallIn(SingletonComponent::class)
+    object TestDependencyProvider {
+
+        @Singleton
+        @Provides
+        fun provideMapViewProducer(): MapViewProducer =
+            MapViewProducer { mockMapView }
+
+        @Singleton
+        @Provides
+        fun provideContentViewSetter(): ViewActionPerformer =
+            ViewActionPerformer { /* do nothing */ }
+
+    }
+
+
+}

--- a/app/src/test/java/com/github/multimatum_team/multimatum/DisplayLocationActivityTest.kt
+++ b/app/src/test/java/com/github/multimatum_team/multimatum/DisplayLocationActivityTest.kt
@@ -63,8 +63,10 @@ class DisplayLocationActivityTest {
         val mockPointAnnotationManager: PointAnnotationManager = mock()
 
         var cameraOptions: CameraOptions? = null
-        var pointAnnotationManagerCreated = false
+        var pointAnnotationManagerHasBeenCreated = false
 
+        // Setup the mocks to set the variables with the values they are given as arguments
+        // and to return other mocks when needed
         whenever(mockMapView.getMapboxMap()).thenReturn(mockMapBoxMap)
         whenever(mockMapBoxMap.loadStyleUri(anyString(), any<Style.OnStyleLoaded>())).then {
             val onStyleLoaded: Style.OnStyleLoaded = it.getArgument(1)
@@ -80,7 +82,7 @@ class DisplayLocationActivityTest {
             mockPointAnnotationManager
         )
         whenever(mockPointAnnotationManager.create(any<PointAnnotationOptions>())).then {
-            pointAnnotationManagerCreated = true
+            pointAnnotationManagerHasBeenCreated = true
             mock<PointAnnotation>()
         }
 
@@ -89,13 +91,11 @@ class DisplayLocationActivityTest {
         val activityScenario: ActivityScenario<DisplayLocationActivity> =
             ActivityScenario.launch(intent)
 
-        activityScenario.use {
-
-        }
+        activityScenario.use {  }
 
         assertNotNull(cameraOptions)
         assertEquals(14.0, cameraOptions!!.zoom)
-        assertTrue(pointAnnotationManagerCreated)
+        assertTrue(pointAnnotationManagerHasBeenCreated)
 
     }
 


### PR DESCRIPTION
Test for `DisplayLocationActivity`. This test (ab)uses DI, injecting functions that take other functions as an argument... The purpose of this confusing pattern is to disable some function calls inside `onCreate` when the function is run in tests (because they throw exceptions otherwise). This is a bit ugly, but it is the only way that I found to make this test work, and I think that despite that the test is meaningful.

Close #289 