### PR TITLE
Prevent anonymous users from accessing the groups page

### DIFF
--- a/app/src/main/java/com/github/multimatum_team/multimatum/activity/MainActivity.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/activity/MainActivity.kt
@@ -57,7 +57,6 @@ class MainActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
 
         Firebase.initialize(this)
-        Firebase.firestore.clearPersistence()
 
         setContentView(R.layout.activity_main)
 

--- a/app/src/main/java/com/github/multimatum_team/multimatum/activity/MainActivity.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/activity/MainActivity.kt
@@ -9,6 +9,7 @@ import android.widget.AdapterView
 import android.widget.ListView
 import android.widget.Spinner
 import androidx.activity.viewModels
+import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.app.ActivityCompat
@@ -45,9 +46,6 @@ class MainActivity : AppCompatActivity() {
 
     @Inject
     lateinit var pdfRepository: PdfRepository
-
-    @Inject
-    lateinit var alertDialogBuilderProducer: AlertDialogBuilderProducer
 
     private val authViewModel: AuthViewModel by viewModels()
     private val deadlineListViewModel: DeadlineListViewModel by viewModels()
@@ -216,8 +214,7 @@ class MainActivity : AppCompatActivity() {
                 startActivity(intent)
             }
             is AnonymousUser ->
-                alertDialogBuilderProducer
-                    .produce(this)
+                AlertDialog.Builder(this)
                     .setTitle(getString(R.string.main_activity_go_to_groups_error_dialog_title))
                     .setMessage(getString(R.string.main_activity_go_to_groups_error_dialog_message))
                     .setPositiveButton(getString(R.string.main_activity_go_to_groups_error_dialog_go_to_sign_in_page)) { dialog, _ ->

--- a/app/src/main/java/com/github/multimatum_team/multimatum/activity/MainActivity.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/activity/MainActivity.kt
@@ -9,7 +9,6 @@ import android.widget.AdapterView
 import android.widget.ListView
 import android.widget.Spinner
 import androidx.activity.viewModels
-import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.app.ActivityCompat
@@ -46,6 +45,9 @@ class MainActivity : AppCompatActivity() {
 
     @Inject
     lateinit var pdfRepository: PdfRepository
+
+    @Inject
+    lateinit var alertDialogBuilderProducer: AlertDialogBuilderProducer
 
     private val authViewModel: AuthViewModel by viewModels()
     private val deadlineListViewModel: DeadlineListViewModel by viewModels()
@@ -214,7 +216,8 @@ class MainActivity : AppCompatActivity() {
                 startActivity(intent)
             }
             is AnonymousUser ->
-                AlertDialog.Builder(this)
+                alertDialogBuilderProducer
+                    .produce(this)
                     .setTitle(getString(R.string.main_activity_go_to_groups_error_dialog_title))
                     .setMessage(getString(R.string.main_activity_go_to_groups_error_dialog_message))
                     .setPositiveButton(getString(R.string.main_activity_go_to_groups_error_dialog_go_to_sign_in_page)) { dialog, _ ->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,6 +4,10 @@
     <string name="calendar_deadline_input_text">Enter new deadline…</string>
     <string name="calender_add_new_deadline_button_text">Add</string>
     <string name="calendar_button_text">Calendar</string>
+    <string name="main_activity_go_to_groups_error_dialog_title">Error</string>
+    <string name="main_activity_go_to_groups_error_dialog_message">Cannot use groups when signed-in anonymously\nPlease sign-in with a Google account</string>
+    <string name="main_activity_go_to_groups_error_dialog_go_to_sign_in_page">Go to sign-in page</string>
+    <string name="main_activity_go_to_groups_error_dialog_cancel">Cancel</string>
     <string name="main_settings_activity_title">Settings</string>
     <string name="main_settings_account_section_title">Account</string>
     <string name="main_settings_account_button">My account</string>


### PR DESCRIPTION
To prevent anonymous users from creating groups which makes the app crash, the "groups" button on the main page now checks whether the user is signed-in or anonymous. In the former case, it behaves as before, starting the groups activity, but in the latter, an error message is displayed to signal the user that the groups feature is reserved to signed-in users. The user can either dismiss the message or click on a button to be redirected to the sign-in page.