### PR TITLE
Ignore deserialization errors from Firebase

### DIFF
--- a/app/src/androidTest/java/com/github/multimatum_team/multimatum/util/MockGroupRepository.kt
+++ b/app/src/androidTest/java/com/github/multimatum_team/multimatum/util/MockGroupRepository.kt
@@ -40,8 +40,8 @@ class MockGroupRepository(initialContents: List<UserGroup>) : GroupRepository() 
             })
         }
 
-    override suspend fun fetch(id: GroupID): UserGroup =
-        groups[id]!!
+    override suspend fun fetch(id: GroupID): UserGroup? =
+        groups[id]
 
     override suspend fun fetchAll(): Map<GroupID, UserGroup> =
         groups.filterValues { group -> group.members.contains(_userID) }

--- a/app/src/debug/java/com/github/multimatum_team/multimatum/LogUtilImpl.kt
+++ b/app/src/debug/java/com/github/multimatum_team/multimatum/LogUtilImpl.kt
@@ -16,6 +16,11 @@ object LogUtilImpl: LogUtil.FunctionsProvider {
         Log.d(createTag(currFunc), str)
     }
 
+    override fun warningLog(str: String) = safeExec {
+        val currFunc = Thread.currentThread().stackTrace[STACK_IDX_FOR_ENV_FUNC]
+        Log.w(createTag(currFunc), str)
+    }
+
     override fun logFunctionCall() = safeExec {
         val currFunc = Thread.currentThread().stackTrace[STACK_IDX_FOR_ENV_FUNC]
         val msg = "${currFunc.methodName} called"

--- a/app/src/main/java/com/github/multimatum_team/multimatum/LogUtil.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/LogUtil.kt
@@ -25,6 +25,11 @@ object LogUtil {
     fun debugLog(str: String) = instance.debugLog(str)
 
     /**
+     * Displays the message in the logs with level 'warning', inferring the tag
+     */
+    fun warningLog(str: String) = instance.warningLog(str)
+
+    /**
      * Reports that the function in which it is called has been called
      */
     fun logFunctionCall() = instance.logFunctionCall()
@@ -40,6 +45,11 @@ object LogUtil {
          * Displays the message in the logs with level 'debug', inferring the tag
          */
         fun debugLog(str: String)
+
+        /**
+         * Displays the message in the logs with level 'warning', inferring the tag
+         */
+        fun warningLog(str: String)
 
         /**
          * Reports that the function in which it is called has been called

--- a/app/src/main/java/com/github/multimatum_team/multimatum/repository/GroupRepository.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/repository/GroupRepository.kt
@@ -28,7 +28,7 @@ abstract class GroupRepository {
      * Fetch a single group from its ID.
      * @param id the ID of the group to fetch
      */
-    abstract suspend fun fetch(id: GroupID): UserGroup
+    abstract suspend fun fetch(id: GroupID): UserGroup?
 
     /**
      * Fetch all groups of which the user is a member.

--- a/app/src/main/java/com/github/multimatum_team/multimatum/util/ListUtil.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/util/ListUtil.kt
@@ -1,0 +1,8 @@
+package com.github.multimatum_team.multimatum.util
+
+fun <T, K, V> List<T>.associateNotNull(transform: (T) -> Pair<K, V?>): Map<K, V> =
+    this.mapNotNull {
+        val (k, v) = transform(it)
+        v?.let { k to v }
+    }
+    .toMap()

--- a/app/src/main/java/com/github/multimatum_team/multimatum/viewmodel/GroupViewModel.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/viewmodel/GroupViewModel.kt
@@ -141,11 +141,15 @@ class GroupViewModel @Inject constructor(
      * Generate invite link to join a group given from its ID.
      * @param id the ID of the group to which we want to invite users
      */
-    fun generateInviteLink(id: GroupID, callback: (Uri) -> Unit) =
+    fun generateInviteLink(id: GroupID, callback: (Uri?) -> Unit) =
         viewModelScope.launch {
-            val group = groupRepository.fetch(id)
-            val linkTitle = context.getString(R.string.group_invite_link_title, group.name)
-            val linkDescription = context.getString(R.string.group_invite_link_description)
-            callback(groupRepository.generateInviteLink(id, linkTitle, linkDescription))
+            when (val group = groupRepository.fetch(id)) {
+                null -> callback(null)
+                else -> {
+                    val linkTitle = context.getString(R.string.group_invite_link_title, group.name)
+                    val linkDescription = context.getString(R.string.group_invite_link_description)
+                    callback(groupRepository.generateInviteLink(id, linkTitle, linkDescription))
+                }
+            }
         }
 }

--- a/app/src/release/java/com/github/multimatum_team/multimatum/LogUtilImpl.kt
+++ b/app/src/release/java/com/github/multimatum_team/multimatum/LogUtilImpl.kt
@@ -9,6 +9,8 @@ object LogUtilImpl: LogUtil.FunctionsProvider {
 
     override fun debugLog(str: String) = doNothing()
 
+    override fun warningLog(str: String) = doNothing()
+
     override fun logFunctionCall() = doNothing()
 
     override fun logFunctionCall(str: String) = doNothing()

--- a/app/src/test/java/com/github/multimatum_team/multimatum/GroupDetailsActivityTest.kt
+++ b/app/src/test/java/com/github/multimatum_team/multimatum/GroupDetailsActivityTest.kt
@@ -128,7 +128,7 @@ class GroupDetailsActivityTest {
                 .perform(ViewActions.pressImeActionButton())
             assertThat(
                 "Group name has been updated",
-                groupRepository.fetch("0").name,
+                groupRepository.fetch("0")!!.name,
                 equalTo("Multimatum")
             )
         }

--- a/app/src/test/java/com/github/multimatum_team/multimatum/GroupInviteActivityTest.kt
+++ b/app/src/test/java/com/github/multimatum_team/multimatum/GroupInviteActivityTest.kt
@@ -98,7 +98,7 @@ class GroupInviteActivityTest {
     private suspend fun groupInviteIntent(groupID: GroupID): Intent {
         val intent =
             Intent(context, GroupInviteActivity::class.java)
-        val group = groupRepository.fetch(groupID)
+        val group = groupRepository.fetch(groupID)!!
         val linkTitle = context.getString(R.string.group_invite_link_title, group.name)
         val linkDescription = context.getString(R.string.group_invite_link_description)
         val inviteLink = groupRepository.generateInviteLink(groupID, linkTitle, linkDescription)
@@ -119,7 +119,7 @@ class GroupInviteActivityTest {
                 .perform(click())
             assertThat(
                 "Group contains invited user",
-                groupRepository.fetch("2").members,
+                groupRepository.fetch("2")!!.members,
                 hasItem(joseph.id)
             )
         }
@@ -137,7 +137,7 @@ class GroupInviteActivityTest {
                 .perform(click())
             assertThat(
                 "Group contains invited user",
-                groupRepository.fetch("2").members,
+                groupRepository.fetch("2")!!.members,
                 not(hasItem(joseph.id))
             )
         }

--- a/app/src/test/java/com/github/multimatum_team/multimatum/util/MockGroupRepository.kt
+++ b/app/src/test/java/com/github/multimatum_team/multimatum/util/MockGroupRepository.kt
@@ -40,8 +40,8 @@ class MockGroupRepository(initialContents: List<UserGroup>) : GroupRepository() 
             })
         }
 
-    override suspend fun fetch(id: GroupID): UserGroup =
-        groups[id]!!
+    override suspend fun fetch(id: GroupID): UserGroup? =
+        groups[id]
 
     override suspend fun fetchAll(): Map<GroupID, UserGroup> =
         groups.filterValues { group -> group.members.contains(_userID) }


### PR DESCRIPTION
As described in #299, we should avoid that ill-formed data makes the application crash, especially since there is no way for the user to clear the Firebase cache. This PR prevents the app from crashing simply by filtering out deadlines and groups that couldn't be parser.
The code in `FirebaseDeadlineRepository.deserializedDeadline` isn't very good, but I couldn't figure out how to write it in a better way, I'm open to suggestions.

Closes #299 