### PR TITLE
Refinement/UI typos (and other fixes/improvements)

### DIFF
--- a/app/src/main/java/com/github/multimatum_team/multimatum/DependenciesProvider.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/DependenciesProvider.kt
@@ -189,3 +189,18 @@ object DisplayLocationActivityModule {
         ViewActionPerformer { viewAction -> viewAction() }
 
 }
+
+/**
+ * Container for a function that returns true iff the app is on foreground
+ */
+data class AppOnForegroundChecker(val isAppOnForeground: (Context) -> Boolean)
+
+@Module
+@InstallIn(SingletonComponent::class)
+object ProcrastinationDetectorModule {
+
+    @Provides
+    fun provideAppOnForegroundChecker(): AppOnForegroundChecker =
+        AppOnForegroundChecker(MultimatumApp::isAppOnForeground)
+
+}

--- a/app/src/main/java/com/github/multimatum_team/multimatum/MultimatumApp.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/MultimatumApp.kt
@@ -6,6 +6,7 @@ import android.app.Application
 import android.content.Context
 import android.content.SharedPreferences
 import android.os.Bundle
+import android.widget.Toast
 import com.github.multimatum_team.multimatum.LogUtil.debugLog
 import com.github.multimatum_team.multimatum.LogUtil.logFunctionCall
 import com.github.multimatum_team.multimatum.activity.MainSettingsActivity.Companion.PROCRASTINATION_FIGHTER_ENABLED_PREF_KEY
@@ -41,7 +42,7 @@ class MultimatumApp : Application(), Application.ActivityLifecycleCallbacks {
 
     override fun onActivityResumed(activity: Activity) {
         logFunctionCall("resumed ${activity.localClassName}")
-        val onForeground = isAppOnForeground()
+        val onForeground = isAppOnForeground(applicationContext)
         debugLog(if (onForeground) "app is on foreground" else "app is on background")
         if (onForeground){
             stopProcrastinationDetectorIfActive()
@@ -54,7 +55,7 @@ class MultimatumApp : Application(), Application.ActivityLifecycleCallbacks {
 
     override fun onActivityStopped(activity: Activity) {
         logFunctionCall("stopped ${activity.localClassName}")
-        val onForeground = isAppOnForeground()
+        val onForeground = isAppOnForeground(applicationContext)
         debugLog(if (onForeground) "app is on foreground" else "app is on background")
         if (!onForeground){
             startProcrastinationDetectorIfNeeded()
@@ -85,6 +86,7 @@ class MultimatumApp : Application(), Application.ActivityLifecycleCallbacks {
             )
         ) {
             debugLog("launching ${ProcrastinationDetectorService::class.simpleName}")
+            Toast.makeText(this, R.string.procrastination_fighter_enabled_msg, Toast.LENGTH_SHORT).show()
             ProcrastinationDetectorService.launch(this)
         }
     }
@@ -101,18 +103,20 @@ class MultimatumApp : Application(), Application.ActivityLifecycleCallbacks {
         }
     }
 
-    // Strongly inspired from https://localcoder.org/run-code-when-android-app-is-closed-sent-to-background
-    private fun isAppOnForeground(): Boolean {
-        val activityManager =
-            applicationContext.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
-        val appProcesses = activityManager.runningAppProcesses
-        return if (appProcesses == null) {
-            false
-        } else {
-            val packageName = applicationContext.packageName
-            appProcesses.any { appProcess ->
-                appProcess.importance == ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND
-                        && appProcess.processName == packageName
+    companion object {
+        // Strongly inspired from https://localcoder.org/run-code-when-android-app-is-closed-sent-to-background
+        fun isAppOnForeground(applicationContext: Context): Boolean {
+            val activityManager =
+                applicationContext.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
+            val appProcesses = activityManager.runningAppProcesses
+            return if (appProcesses == null) {
+                false
+            } else {
+                val packageName = applicationContext.packageName
+                appProcesses.any { appProcess ->
+                    appProcess.importance == ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND
+                            && appProcess.processName == packageName
+                }
             }
         }
     }

--- a/app/src/main/java/com/github/multimatum_team/multimatum/activity/AddDeadlineActivity.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/activity/AddDeadlineActivity.kt
@@ -213,6 +213,7 @@ class AddDeadlineActivity : AppCompatActivity() {
     /**
      * Setup a DatePickerDialog that will select a date for the deadline and show it
      */
+    @Suppress("UNUSED_PARAMETER")
     fun selectDate(view: View) {
         // Set what will happen when a date is selected
         val dateSetListener =
@@ -240,6 +241,7 @@ class AddDeadlineActivity : AppCompatActivity() {
     /**
      * Setup a TimePickerDialog that will select a time for the deadline and show it
      */
+    @Suppress("UNUSED_PARAMETER")
     fun selectTime(view: View) {
         // Set what will happen when a time is selected
         val timeSetListener =
@@ -341,6 +343,7 @@ class AddDeadlineActivity : AppCompatActivity() {
     /**
      * Setup an AlertDialog that will select the group of the deadline
      */
+    @Suppress("UNUSED_PARAMETER")
     fun selectGroups(view: View) {
         val alertDialogBuilder = AlertDialog.Builder(this)
 
@@ -364,6 +367,7 @@ class AddDeadlineActivity : AppCompatActivity() {
     /**
      *  Add a deadline based on the data recuperated on the other TextViews
      */
+    @Suppress("UNUSED_PARAMETER")
     fun addDeadline(view: View) {
 
         // Check if the title is not empty
@@ -414,6 +418,7 @@ class AddDeadlineActivity : AppCompatActivity() {
      *  Go to SearchLocationActivity, which allows the user to select a location
      *  for a deadline.
      */
+    @Suppress("UNUSED_PARAMETER")
     fun searchLocation(view: View) {
         val intent = Intent(applicationContext, SearchLocationActivity::class.java)
         getResult.launch(intent)
@@ -477,6 +482,7 @@ class AddDeadlineActivity : AppCompatActivity() {
     /**
      * Launch pdf selection menu
      */
+    @Suppress("UNUSED_PARAMETER")
     fun selectPDF(view: View) {
         PDFUtil.selectPdfIntent {
             startForResult.launch(it)

--- a/app/src/main/java/com/github/multimatum_team/multimatum/activity/AddDeadlineActivity.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/activity/AddDeadlineActivity.kt
@@ -119,7 +119,7 @@ class AddDeadlineActivity : AppCompatActivity() {
         }
         KeyboardVisibilityEvent.setEventListener(this, object : KeyboardVisibilityEventListener {
             override fun onVisibilityChanged(isOpen: Boolean) {
-                if (!isOpen){
+                if (!isOpen) {
                     updateDisplayedInfoAfterTitleChange()
                 }
             }
@@ -163,7 +163,7 @@ class AddDeadlineActivity : AppCompatActivity() {
     private fun updateDisplayedInfoAfterTitleChange() {
         // if title parsing was refused the first time then do not ask again
         val currentTitle = textTitle.text.toString()
-        if (currentTitle != titleToIgnoreInParsing){
+        if (currentTitle != titleToIgnoreInParsing) {
             titleToIgnoreInParsing = currentTitle
             val dateTimeExtractionResult = dateTimeExtractor.parse(currentTitle)
             if (dateTimeExtractionResult.dateFound || dateTimeExtractionResult.timeFound) {
@@ -191,17 +191,19 @@ class AddDeadlineActivity : AppCompatActivity() {
 
     private fun launchParsingValidationAlert(res: DateTimeExtractionResult) {
         val alertBuilder = AlertDialog.Builder(this)
-        var message = "title: " + res.text
-        if (res.date != null) (message + "\ndate: " + res.date.toString()).also { message = it }
-        if (res.time != null) (message + "\ntime: " + res.time.toString()).also { message = it }
-        alertBuilder.setCancelable(true).setTitle(R.string.parsing_validation_title)
+        var message = "Title: " + res.text
+        if (res.dateFound) (message + "\nDate: " + res.date.toString()).also { message = it }
+        if (res.timeFound) (message + "\nTime: " + res.time.toString()).also { message = it }
+        alertBuilder.setCancelable(true)
+            .setTitle(R.string.parsing_validation_title)
             .setMessage(message)
-        alertBuilder.setNegativeButton(
-            "Cancel"
-        ) { dialogInterface, _ -> dialogInterface.cancel() }
-        alertBuilder.setPositiveButton(
-            "OK"
-        ) { _, _ -> applyParsing(res) }
+            // swapping negative and positive buttons because we want "yes" before "no"
+            .setNegativeButton(
+                "Yes"
+            ) { _, _ -> applyParsing(res) }
+            .setPositiveButton(
+                "No"
+            ) { dialogInterface, _ -> dialogInterface.cancel() }
         alertBuilder.show()
     }
 

--- a/app/src/main/java/com/github/multimatum_team/multimatum/activity/DeadlineDetailsActivity.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/activity/DeadlineDetailsActivity.kt
@@ -116,6 +116,7 @@ class DeadlineDetailsActivity : AppCompatActivity() {
      * @param view: the current view
      * when clicking ont the button create an intent to launch the QR activity
      */
+    @Suppress("UNUSED_PARAMETER")
     fun goQRGenerator(view: View) {
         val intent = Intent(this, QRGeneratorActivity::class.java)
         val deadline = deadlineListViewModel.getDeadline(id)
@@ -131,6 +132,7 @@ class DeadlineDetailsActivity : AppCompatActivity() {
     /**
      * This display a DatePickerDialog and afterward a TimePickerDialog to modify the date
      */
+    @Suppress("UNUSED_PARAMETER")
     fun changeDateAndTime(view: View) {
         val dateSetListener =
             DatePickerDialog.OnDateSetListener { _, year, monthOfYear, dayOfMonth ->
@@ -184,6 +186,7 @@ class DeadlineDetailsActivity : AppCompatActivity() {
     /**
      * Edit the notification preferences with an AlertDialog
      */
+    @Suppress("UNUSED_PARAMETER")
     fun updateNotifications(view: View) {
         val alertDialogBuilder = AlertDialog.Builder(this)
 
@@ -209,6 +212,7 @@ class DeadlineDetailsActivity : AppCompatActivity() {
     /**
      * Function that put the activity to the Edit Mode or to the Uneditable Mode
      */
+    @Suppress("UNUSED_PARAMETER")
     fun goToEditOrNormalMode(view: View) {
         // Put the title, the date, the done button and the notification text to the edit mode or not
         editTitle(editMode)
@@ -234,6 +238,7 @@ class DeadlineDetailsActivity : AppCompatActivity() {
         editMode = editMode.not()
     }
 
+    @Suppress("UNUSED_PARAMETER")
     fun displayLocationOnMap(view: View) {
         val deadline = deadlineListViewModel.getDeadline(id)
 
@@ -471,6 +476,7 @@ class DeadlineDetailsActivity : AppCompatActivity() {
     /**
      * download the pdf from firebaseStorage
      */
+    @Suppress("UNUSED_PARAMETER")
     fun downloadPdf(view: View) {
 
         pdfRepository.downloadPdf(

--- a/app/src/main/java/com/github/multimatum_team/multimatum/activity/GroupsActivity.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/activity/GroupsActivity.kt
@@ -55,6 +55,7 @@ class GroupsActivity : AppCompatActivity() {
         }
     }
 
+    @Suppress("UNUSED_PARAMETER")
     fun addGroup(view: View) {
         val alertDialogBuilder = alertDialogBuilderProducer.produce(this)
         alertDialogBuilder.setTitle("Create group")

--- a/app/src/main/java/com/github/multimatum_team/multimatum/activity/MainActivity.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/activity/MainActivity.kt
@@ -128,6 +128,7 @@ class MainActivity : AppCompatActivity() {
             }
     }
 
+    @Suppress("UNUSED_PARAMETER")
     private fun onDismissOverride(
         view: ListViewAdapter?,
         position: Int,
@@ -156,12 +157,13 @@ class MainActivity : AppCompatActivity() {
         )
     }
 
-
+    @Suppress("UNUSED_PARAMETER")
     fun goToAddDeadline(view: View) {
         val intent = Intent(this, AddDeadlineActivity::class.java)
         startActivity(intent)
     }
 
+    @Suppress("UNUSED_PARAMETER")
     fun openCodeScanner(view: View) {
         if (ContextCompat.checkSelfPermission(
                 this,
@@ -197,16 +199,19 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
+    @Suppress("UNUSED_PARAMETER")
     fun launchSettingsActivity(view: View) {
         val intent = Intent(this, MainSettingsActivity::class.java)
         startActivity(intent)
     }
 
+    @Suppress("UNUSED_PARAMETER")
     fun openCalendar(view: View) {
         val intent = Intent(this, CalendarActivity::class.java)
         startActivity(intent)
     }
 
+    @Suppress("UNUSED_PARAMETER")
     fun goToGroups(view: View) {
         when (authViewModel.getUser().value!!) {
             is SignedInUser -> {

--- a/app/src/main/java/com/github/multimatum_team/multimatum/activity/MainSettingsActivity.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/activity/MainSettingsActivity.kt
@@ -173,6 +173,7 @@ class MainSettingsActivity : AppCompatActivity() {
             "com.github.multimatum_team.multimatum.activity.MainSettingsActivity.ProcrastinationFighterSensitivity"
     }
 
+    @Suppress("UNUSED_PARAMETER")
     fun goToAccountSettings(view: View) {
         Log.d(TAG, "goToAccountSettings: ${userViewModel.getUser().value}")
         val intent = when (userViewModel.getUser().value!!) {

--- a/app/src/main/java/com/github/multimatum_team/multimatum/activity/QRGeneratorActivity.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/activity/QRGeneratorActivity.kt
@@ -24,6 +24,7 @@ class QRGeneratorActivity : AppCompatActivity() {
     }
 
     //function to return to the main activity
+    @Suppress("UNUSED_PARAMETER")
     fun returnMain(view: View) {
         val intent = Intent(this, MainActivity::class.java)
         startActivity(intent)

--- a/app/src/main/java/com/github/multimatum_team/multimatum/activity/SignInActivity.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/activity/SignInActivity.kt
@@ -59,6 +59,7 @@ class SignInActivity : AppCompatActivity() {
         }
     }
 
+    @Suppress("UNUSED_PARAMETER")
     private fun launchSignInIntent(view: View) {
         // For now we only support Google accounts
         val providers = arrayListOf(

--- a/app/src/main/java/com/github/multimatum_team/multimatum/service/ProcrastinationDetectorSensorListener.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/service/ProcrastinationDetectorSensorListener.kt
@@ -6,17 +6,20 @@ import android.hardware.Sensor
 import android.hardware.SensorEvent
 import android.hardware.SensorEventListener
 import android.widget.Toast
+import com.github.multimatum_team.multimatum.AppOnForegroundChecker
 import com.github.multimatum_team.multimatum.LogUtil
-import com.github.multimatum_team.multimatum.MultimatumApp
 import com.github.multimatum_team.multimatum.R
 import com.github.multimatum_team.multimatum.activity.MainSettingsActivity.Companion.PROCRASTINATION_FIGHTER_SENSITIVITY_PREF_KEY
 import com.github.multimatum_team.multimatum.service.ProcrastinationDetectorService.Companion.DEFAULT_SENSITIVITY
 import com.github.multimatum_team.multimatum.service.ProcrastinationDetectorService.Companion.MAX_SENSITIVITY
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 import kotlin.math.abs
 
 class ProcrastinationDetectorSensorListener(
     private val applicationContext: Context,
-    private val sharedPreferences: SharedPreferences
+    private val sharedPreferences: SharedPreferences,
+    private val appOnForegroundChecker: AppOnForegroundChecker
 ) :
     SensorEventListener {
 
@@ -85,7 +88,7 @@ class ProcrastinationDetectorSensorListener(
     private fun reactToSignificantMove() {
         if (nonReportedDetectionsCnt > 0) {
             nonReportedDetectionsCnt -= 1
-        } else if (MultimatumApp.isAppOnForeground(applicationContext)) {
+        } else if (appOnForegroundChecker.isAppOnForeground(applicationContext)) {
             ProcrastinationDetectorService.stop(applicationContext)
         } else {
             Toast.makeText(

--- a/app/src/main/java/com/github/multimatum_team/multimatum/service/ProcrastinationDetectorSensorListener.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/service/ProcrastinationDetectorSensorListener.kt
@@ -7,6 +7,7 @@ import android.hardware.SensorEvent
 import android.hardware.SensorEventListener
 import android.widget.Toast
 import com.github.multimatum_team.multimatum.LogUtil
+import com.github.multimatum_team.multimatum.MultimatumApp
 import com.github.multimatum_team.multimatum.R
 import com.github.multimatum_team.multimatum.activity.MainSettingsActivity.Companion.PROCRASTINATION_FIGHTER_SENSITIVITY_PREF_KEY
 import com.github.multimatum_team.multimatum.service.ProcrastinationDetectorService.Companion.DEFAULT_SENSITIVITY
@@ -84,6 +85,8 @@ class ProcrastinationDetectorSensorListener(
     private fun reactToSignificantMove() {
         if (nonReportedDetectionsCnt > 0) {
             nonReportedDetectionsCnt -= 1
+        } else if (MultimatumApp.isAppOnForeground(applicationContext)) {
+            ProcrastinationDetectorService.stop(applicationContext)
         } else {
             Toast.makeText(
                 applicationContext,

--- a/app/src/main/java/com/github/multimatum_team/multimatum/service/ProcrastinationDetectorService.kt
+++ b/app/src/main/java/com/github/multimatum_team/multimatum/service/ProcrastinationDetectorService.kt
@@ -12,6 +12,7 @@ import android.hardware.SensorManager
 import android.os.Binder
 import android.os.IBinder
 import android.os.PowerManager
+import com.github.multimatum_team.multimatum.AppOnForegroundChecker
 import com.github.multimatum_team.multimatum.LogUtil.debugLog
 import com.github.multimatum_team.multimatum.LogUtil.logFunctionCall
 import com.github.multimatum_team.multimatum.R
@@ -32,6 +33,9 @@ class ProcrastinationDetectorService : Service(), SensorEventListener {
 
     @Inject
     lateinit var sharedPreferences: SharedPreferences
+
+    @Inject
+    lateinit var appOnForegroundChecker: AppOnForegroundChecker
 
     private var isServiceStarted = false
     private var wakeLock: PowerManager.WakeLock? = null
@@ -76,7 +80,11 @@ class ProcrastinationDetectorService : Service(), SensorEventListener {
     private fun initListenerIfNeeded() {
         if (!this::sensorListener.isInitialized) {
             sensorListener =
-                ProcrastinationDetectorSensorListener(applicationContext, sharedPreferences)
+                ProcrastinationDetectorSensorListener(
+                    applicationContext,
+                    sharedPreferences,
+                    appOnForegroundChecker
+                )
         }
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -72,7 +72,7 @@
     <string name="group_delete_dialog_confirm">Delete</string>
     <string name="group_delete_dialog_cancel">Cancel</string>
     <string name="group_delete_confirmation_dialog">Are you sure you want to delete this group?</string>
-    <string name="parsing_validation_title">Your title can be parse to :</string>
+    <string name="parsing_validation_title">Do you mean this?</string>
     <string name="download_pdf">Download linked pdf</string>
     <string name="addgroup">AddGroup</string>
     <string name="group_invite_deny">Deny</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -42,21 +42,21 @@
     <string name="deadline_created">Deadline created.</string>
     <string name="login_google_text">Sign in with Google</string>
     <string name="generate_qrcode">Generate QRCode</string>
-    <string name="select_date">Select Date</string>
-    <string name="select_time">Select Time</string>
+    <string name="select_date">Select</string>
+    <string name="select_time">Select</string>
     <string name="notification_shared_preference">com.github.multimatum_team.multimatum.notifications</string>
     <string name="not_done">Not Done</string>
     <string name="groups">Groups</string>
     <string name="mapbox_access_token" tools:ignore="Typos">pk.eyJ1IjoibXVsdGltYXR1bSIsImEiOiJjbDMwNHdvaHYwZ21nM2JtdW42MWY0cTRyIn0.T61NTFU2NdeqmCu1CdO9mg</string>
     <string name="display_location_default_msg">No location</string>
     <string name="location_default_msg">No location selected</string>
-    <string name="select_notifications">Select Notifications</string>
+    <string name="select_notifications">Notifications</string>
     <string name="write_description_here">Write description here</string>
     <string name="no_alarm_planned">No Alarm Planned</string>
     <string name="alarm_X_before">Alarm %s before</string>
     <string name="not_in_any_group">Not in any group</string>
     <string name="in_the_group_X">In the group: %s</string>
-    <string name="select_group">Select Group</string>
+    <string name="select_group">Group</string>
     <string name="group_owner">Owner: %s</string>
     <string name="group_invite">Invite</string>
     <string name="group_details_group_name_hint">Group name</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -18,6 +18,7 @@
     <string name="main_settings_procrastination_fighter_section_title">Procrastination fighter</string>
     <string name="main_settings_enable_procrastination_fighter_button">Notify me when I am procrastinating</string>
     <string name="main_settings_procrastination_fighter_sensitivity">Sensitivity</string>
+    <string name="procrastination_fighter_enabled_msg">Procrastination detection will start in a few seconds</string>
     <string name="main_open_settings_but_content_descr">Settings button</string>
     <string name="isAlreadyDue">Is already Due</string>
     <string name="done">Done</string>

--- a/app/src/test/java/com/github/multimatum_team/multimatum/service/ProcrastinationDetectorServiceTest.kt
+++ b/app/src/test/java/com/github/multimatum_team/multimatum/service/ProcrastinationDetectorServiceTest.kt
@@ -10,7 +10,9 @@ import android.widget.Toast
 import androidx.test.espresso.intent.Intents
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.rule.ServiceTestRule
+import com.github.multimatum_team.multimatum.AppOnForegroundChecker
 import com.github.multimatum_team.multimatum.DependenciesProvider
+import com.github.multimatum_team.multimatum.ProcrastinationDetectorModule
 import com.github.multimatum_team.multimatum.R
 import com.github.multimatum_team.multimatum.activity.MainSettingsActivity
 import dagger.Module
@@ -40,7 +42,7 @@ import org.robolectric.android.controller.ServiceController
 import org.robolectric.shadows.ShadowToast
 import javax.inject.Singleton
 
-@UninstallModules(DependenciesProvider::class)
+@UninstallModules(DependenciesProvider::class, ProcrastinationDetectorModule::class)
 @HiltAndroidTest
 @RunWith(AndroidJUnit4::class)
 class ProcrastinationDetectorServiceTest {
@@ -374,6 +376,11 @@ class ProcrastinationDetectorServiceTest {
         @Singleton
         @Provides
         fun provideSharedPreferences(): SharedPreferences = mockSharedPreferences
+
+        @Singleton
+        @Provides
+        fun provideAppOnForegroundChecker(): AppOnForegroundChecker =
+            AppOnForegroundChecker { false }
 
     }
 


### PR DESCRIPTION
In this PR:
* Shorten the text in the buttons of `AddDeadlineActivity` because of lack of space on some phones (including mine...)
* When adding a deadline, run the parser to search for a date/time when the keyboard is closed
* Don't propose parsed time info if it did not change from last time it was proposed and the user already rejected it
* Supress `parameter view is never used` warnings
* More intuitive deadline parsing popup
* Toast when app is closed and procrastination detector is about to start
* Fix bug of procrastination detector not disabling itself when coming back to the app

Close #308 
Close #309 